### PR TITLE
Remove legacy repository reference

### DIFF
--- a/docs/deployment-and-operations.md
+++ b/docs/deployment-and-operations.md
@@ -83,7 +83,6 @@ Typical manual rollback pattern:
 ## Operational Notes
 
 - promotion publishes the application and runner to separate trusted GHCR repositories
-- images published before the repository rename remain under `ghcr.io/llody9977/secure-ci-deploy/...` as legacy deployment paths; new promotions use `ghcr.io/llody9977/artifactgate/...`
 - the secure default binds to localhost, expects HTTPS through a reverse proxy, and enables secure cookies
 - new promotions should preserve upstream multi-arch manifests so ARM hosts can pull native images
 - re-scan findings are surfaced as GitHub issues when a previously accepted image crosses the review threshold


### PR DESCRIPTION
## Summary

- remove the remaining documentation pointer to the pre-rename repository path
- keep deployment guidance focused on the ArtifactGate package names

## Verification

- searched the tracked repository for `secure-ci-deploy`
- confirmed no old-name references remain