### PR TITLE
Frame ArtifactGate as a container assurance gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,73 @@
-# ArtifactGate: Trusted Vendor Image Promotion for n8n
+# ArtifactGate: Evidence-Based Admission Control for Third-Party Containers
 
 [![CI](https://github.com/llody9977/artifactgate/actions/workflows/ci.yml/badge.svg)](https://github.com/llody9977/artifactgate/actions/workflows/ci.yml)
 [![Image Promotion](https://github.com/llody9977/artifactgate/actions/workflows/image-promotion.yml/badge.svg)](https://github.com/llody9977/artifactgate/actions/workflows/image-promotion.yml)
 [![Re-Scan](https://github.com/llody9977/artifactgate/actions/workflows/rescan.yml/badge.svg)](https://github.com/llody9977/artifactgate/actions/workflows/rescan.yml)
 
-I built ArtifactGate as a personal reference project to work through a practical question: if I need to run a third-party container image, what evidence should I collect before treating it as deployable?
+I built ArtifactGate around a practical problem: pulling a third-party container is easy, but accepting the supplier's risk along with it is also easy.
 
-The example uses n8n. The pipeline resolves the application and external runner to immutable digests, scans and enriches the findings, records the promotion decision, publishes the accepted pair to GHCR, and provides a hardened deployment example.
+A familiar image name or a green vulnerability scan is useful, but neither is proof that the image came through the expected path, contains only acceptable components, or is the same set of bytes later deployed. Tags can move. SBOMs can be incomplete. New CVEs appear after release. A sidecar can also carry a separate supply-chain risk from the main application.
 
-The example workload is `n8nio/n8n`. The same pattern is meant to demonstrate how a vendor image can be evaluated as a trust and decision problem, not only as a raw CVE count.
+ArtifactGate is a personal reference implementation of an **evidence-based admission and promotion gate**. It treats a vendor image as untrusted input, resolves the exact application and runner digests, gathers security evidence, applies a documented decision policy, and promotes only the accepted pair to a controlled registry namespace. Deployment then verifies the promotion attestations and uses those same immutable digests.
 
-## What This Repo Does
+The example workload is `n8nio/n8n`, but the pattern is broader: do not turn third-party software into an internally trusted artifact until you can explain what was assessed, what was accepted, and what will actually run.
+
+> **Core idea:** trust is not inherited from a tag or created by a scanner. It is a recorded decision about an exact artifact, supported by evidence and bounded by what that evidence can prove.
+
+## The Decision ArtifactGate Produces
+
+ArtifactGate is designed to answer six questions before deployment:
+
+| Question | Evidence or control |
+| :--- | :--- |
+| **Source** — Did this come from an allowed upstream? | source allowlist and version intake policy |
+| **Identity** — Which exact bytes were assessed? | OCI digest resolution and digest pinning |
+| **Composition** — What is declared to be inside? | SPDX SBOM generation and attestation |
+| **Risk** — What security signals are known now? | vulnerability, malware, secret, licence, KEV, EPSS, age and bounded runtime checks |
+| **Decision** — Why was it promoted? | policy gate or explicit, scoped and expiring waiver |
+| **Continuity** — Are we deploying and monitoring the same artifact? | keyless promotion attestation, verification before deployment and scheduled re-scan |
+
+These are complementary controls. Provenance is not an SBOM, an SBOM is not a vulnerability verdict, a scan is not proof of non-exploitability, and a signature does not make unsafe content safe.
+
+## What This Repository Does
 
 - allowlists the upstream source image and enforces semver-style version intake
-- resolves and scans an immutable upstream digest
+- resolves and scans immutable application and runner digests
 - enriches findings with `KEV`, `EPSS`, CVE age, and runtime reachability context
 - promotes an approved application and runner pair to GHCR
 - attests provenance and SBOM data for the promoted artifact
 - re-scans the latest promoted release on a schedule
 - provides a hardened Docker Compose deployment for n8n
+
+## Standards-Informed Framing
+
+ArtifactGate uses the following publications as design references. This is an engineering mapping, not a certification or claim of NIST or SLSA conformance.
+
+| Reference | How it informs ArtifactGate |
+| :--- | :--- |
+| [NIST SP 800-161 Rev. 1](https://csrc.nist.gov/pubs/sp/800/161/r1/upd1/final) | Frames third-party software as a cybersecurity supply-chain risk that needs due diligence, assessment, mitigation and continuing oversight. |
+| [NIST SP 800-190](https://csrc.nist.gov/pubs/sp/800/190/final) | Informs trusted-image handling, vulnerability management, registry controls and hardened container runtime configuration. |
+| [NIST SP 800-218 (SSDF)](https://csrc.nist.gov/pubs/sp/800/218/final) | Informs verification of third-party components and the collection and protection of release provenance and integrity evidence. |
+| [NIST SP 800-204D](https://csrc.nist.gov/pubs/sp/800/204/d/final) | Provides the closest architectural framing for integrating provenance, attestations, SBOMs and supply-chain controls into CI/CD. |
+| [SLSA v1.2](https://slsa.dev/spec/v1.2/) | Supplies a useful model for provenance and verification expectations. ArtifactGate does not claim a SLSA level for an upstream image it did not build. |
+
+NIST describes SBOMs as a way to improve transparency, provenance and the speed of vulnerability identification. ArtifactGate therefore keeps the SBOM tied to the promoted digest and feeds the inventory into ongoing risk review. It does not treat the presence of an SBOM as proof that the inventory is complete or that the artifact is secure.
+
+## Where Trust and Rules Are Set
+
+The rules are kept in the repository so a change is reviewable and leaves source history. The policy files state the intent; the workflow and enrichment script enforce the decision.
+
+| Control point | Current rule | Source of truth |
+| :--- | :--- | :--- |
+| Trusted upstream intake | only `n8nio/n8n` and `n8nio/runners`; strict `x.y.z` versions, with `latest` resolved before use | [`policy/image-ingestion-policy.yml`](policy/image-ingestion-policy.yml) |
+| Upstream signature handling | warning-only because the vendor signature is not currently available; the accepted gap and review date are recorded | [`policy/image-ingestion-policy.yml`](policy/image-ingestion-policy.yml) |
+| Vulnerability gate | critical/high findings require review for KEV, age ≥30 days, EPSS ≥2%, or unknown required evidence | [`policy/vulnerability-gate-policy.yml`](policy/vulnerability-gate-policy.yml) and [`enrich_findings.py`](.github/scripts/enrich_findings.py) |
+| Manual exception | `trusted-promotion` environment approval plus every gated CVE, meaningful justification, compensating controls and future expiry | [`image-promotion.yml`](.github/workflows/image-promotion.yml) |
+| Trusted outputs | separate ArtifactGate GHCR repositories and attestations for the application and runner | [`signing-and-attestation.md`](docs/signing-and-attestation.md) |
+| Deployment admission | verify both subjects against owner `llody9977`, then deploy both by immutable digest | [`install.sh`](iac/n8n/install.sh) |
+| Continuing review | weekly re-scan of the latest promoted release, with a security issue when risk crosses the current gate | [`rescan.yml`](.github/workflows/rescan.yml) |
+
+When adapting the pattern to another vendor, start by changing the intake allowlist through a pull request, confirming the vendor's own signature or provenance mechanism, defining risk thresholds suitable for the environment, and configuring independent reviewers for the protected promotion environment.
 
 ## Pipeline Flow
 
@@ -31,15 +80,17 @@ flowchart TD
     E --> F{"Approval gate"}
     F -->|Lower-risk| G["Auto-promote to GHCR"]
     F -->|Higher-risk| H["Manual approval"]
-    G --> I["Attest provenance and SBOM"]
+    G --> I["Attest promotion provenance and SBOM"]
     H --> I
     I --> J["Create trusted release"]
     J --> K["Scheduled re-scan of latest promoted release"]
 ```
 
-## Assurance boundary
+## Assurance Boundary
 
-A successful promotion does not mean that an image is vulnerability-free. It means only that the image pair passed the project's documented checks, or that identified exceptions were explicitly reviewed with an expiry date. Tracee observations cover the exercised smoke-test paths; a file that was not observed is not proven unreachable.
+A successful promotion does not mean that an image is vulnerability-free, compliant, or safe for every environment. It means only that the exact image pair passed this project's documented checks, or that identified exceptions were explicitly accepted with scope, justification and an expiry date.
+
+The GitHub OIDC attestation proves that ArtifactGate's promotion workflow handled a particular digest. It does **not** prove how the upstream vendor originally built that digest unless separately verified upstream provenance exists. Likewise, Tracee observations cover only the exercised smoke-test paths; a file that was not observed is not proven unreachable.
 
 ## Quick Start
 
@@ -96,9 +147,12 @@ To run image promotion manually:
 ## References
 
 - [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
-- [NIST SP 800-53 Rev. 5](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)
+- [NIST SP 800-161 Rev. 1](https://csrc.nist.gov/pubs/sp/800/161/r1/upd1/final)
+- [NIST SP 800-190](https://csrc.nist.gov/pubs/sp/800/190/final)
+- [NIST SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final)
 - [NIST SP 800-204D](https://csrc.nist.gov/pubs/sp/800/204/d/final)
-- [SLSA v1.0 specification](https://slsa.dev/spec/v1.0/)
+- [NIST software supply-chain SBOM guidance](https://www.nist.gov/itl/executive-order-14028-improving-nations-cybersecurity/software-supply-chain-security-guidance-20)
+- [SLSA v1.2 specification](https://slsa.dev/spec/v1.2/)
 - [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
 - [FIRST EPSS](https://www.first.org/epss/)
 - [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker)

--- a/docs/architecture-and-trust.md
+++ b/docs/architecture-and-trust.md
@@ -6,6 +6,29 @@ This repository is designed to reduce the risk of promoting a third-party image 
 
 The example image is `n8nio/n8n`, but the architecture is meant to illustrate a broader vendor-image promotion pattern.
 
+## Trust States
+
+ArtifactGate uses “trusted” as a local policy state, not as a statement that the
+vendor or container is universally secure.
+
+1. **Upstream candidate** — an allowed vendor reference that has not yet earned a
+   deployment decision. A moving label such as `latest` is resolved to a semantic
+   version and then to immutable application and runner digests.
+2. **Assessed pair** — the exact digests have composition, vulnerability, malware,
+   secret, licence and bounded runtime evidence attached. This evidence can still
+   contain unknowns and findings.
+3. **Promoted pair** — policy allowed the assessed pair, or an accountable reviewer
+   accepted every gated finding through a scoped and expiring exception. Both images
+   are copied to the controlled ArtifactGate GHCR namespaces and attested separately.
+4. **Admitted deployment** — the installer verifies both promotion attestations and
+   deploys the same immutable digests. Scheduled re-scanning can later challenge the
+   earlier decision as risk information changes.
+
+This separation matters because controls answer different questions. The upstream
+digest establishes byte identity; the SBOM describes known composition; scanning and
+enrichment support a risk decision; the ArtifactGate attestation records the promotion
+path; and runtime hardening limits impact. None is a substitute for the others.
+
 ## Threat Model Mapping
 
 | Threat pattern | Why it matters here | Primary control in this repo |
@@ -71,6 +94,36 @@ In practical terms, the promotion path avoids a long-lived registry password or 
 ## Framework Alignment
 
 These frameworks are used as design references, not blanket compliance claims.
+
+### NIST SP 800-161 Rev. 1
+
+Useful here for treating acquired third-party software as a continuing cybersecurity
+supply-chain risk rather than a one-time download decision.
+
+Examples in this repo:
+
+- explicit supplier and image intake rules
+- documented risk acceptance and review dates
+- evidence retained with the promotion decision
+- scheduled re-assessment after acquisition
+
+### NIST SP 800-190
+
+Useful here for container-specific image trust, vulnerability management, registry
+control and runtime configuration.
+
+Examples in this repo:
+
+- controlled promotion namespace
+- immutable image references
+- pre-promotion and recurring vulnerability assessment
+- least-privilege Compose configuration
+
+### NIST SP 800-218 (SSDF)
+
+Useful here for third-party component verification and collecting provenance data for
+release components. ArtifactGate is a consumer and promoter of the example vendor image;
+it does not claim to implement the vendor's development lifecycle.
 
 ### OWASP Top 10 CI/CD Security Risks
 

--- a/site/index.html
+++ b/site/index.html
@@ -1,15 +1,137 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>ArtifactGate evidence</title><link rel="stylesheet" href="style.css"></head>
-<body><main>
-  <p class="eyebrow">PERSONAL REFERENCE PROJECT · PUBLIC EVIDENCE</p>
-  <h1>ArtifactGate</h1>
-  <p class="lede">A controlled path for evaluating, promoting and deploying third-party n8n container images as an attested, digest-pinned application and runner pair.</p>
-  <section><h2>Latest promoted bundle</h2><dl id="release"><dt>Status</dt><dd>Loading release evidence…</dd></dl><p><a id="release-link" href="https://github.com/llody9977/artifactgate/releases">View releases</a></p></section>
-  <section><h2>What a promotion means</h2><p>A successful promotion means the bundle passed the documented checks or an explicit, expiring exception was approved. It does not certify that either image is vulnerability-free or suitable for a particular environment.</p></section>
-  <section><h2>Evidence boundaries</h2><p>Tracee results cover only the exercised smoke-test paths. “Not observed” does not prove that vulnerable code is unreachable. KEV, EPSS and scanner data can be delayed, revised, incomplete or incorrect.</p></section>
-  <section><h2>Verify before deployment</h2><pre><code>gh attestation verify oci://IMAGE@sha256:DIGEST -o llody9977</code></pre><p>Both the n8n image and external runner must be verified and deployed by immutable digest.</p></section>
-  <footer>© 2026 <a href="https://github.com/llody9977">llody9977</a> · <a href="https://github.com/llody9977/artifactgate/blob/main/LICENSE">Apache-2.0</a> · <a href="https://github.com/llody9977/artifactgate#disclaimer">Disclaimer</a></footer>
-</main><script>
-fetch('evidence.json').then(r=>r.json()).then(x=>{document.querySelector('#release').innerHTML=`<dt>Release</dt><dd>${x.name||x.tag_name}</dd><dt>Published</dt><dd>${new Date(x.published_at).toLocaleString()}</dd>`;document.querySelector('#release-link').href=x.html_url}).catch(()=>{});
-</script></body></html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="ArtifactGate is an evidence-based admission and promotion gate for third-party container images.">
+  <title>ArtifactGate · Evidence before deployment</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main>
+  <header class="hero">
+    <p class="eyebrow">PERSONAL REFERENCE PROJECT · CONTAINER SUPPLY-CHAIN ASSURANCE</p>
+    <h1>Evidence before deployment.</h1>
+    <p class="lede">ArtifactGate treats a third-party container as untrusted input until an exact, immutable image pair has enough evidence for a recorded promotion decision.</p>
+    <p class="principle">A trusted name is not provenance. An SBOM is not a verdict. A signature does not make unsafe content safe.</p>
+    <div class="actions"><a class="button" href="https://github.com/llody9977/artifactgate">View repository</a><a href="#evidence">Latest evidence</a></div>
+  </header>
+
+  <section>
+    <p class="kicker">THE PROBLEM</p>
+    <h2>Using a vendor image transfers risk into your environment</h2>
+    <p>A mutable tag can point to different bytes tomorrow. The image can contain vulnerable, malicious or poorly maintained components. Its upstream build history may be absent. A clean scan can become stale, and the application sidecar may carry a separate risk from the main image.</p>
+    <p>ArtifactGate does not assume that these uncertainties disappear. It makes them visible, applies policy to the evidence available now, and records the boundary of the decision.</p>
+  </section>
+
+  <section>
+    <p class="kicker">THE DECISION MODEL</p>
+    <h2>Six questions, one exact artifact pair</h2>
+    <div class="grid">
+      <article><span>01</span><h3>Source</h3><p>Did it come from an allowed upstream and an accepted version?</p></article>
+      <article><span>02</span><h3>Identity</h3><p>Which immutable OCI digests were actually assessed?</p></article>
+      <article><span>03</span><h3>Composition</h3><p>What does the digest-bound SPDX SBOM declare is inside?</p></article>
+      <article><span>04</span><h3>Risk</h3><p>What do CVE, KEV, EPSS, age, malware, secret and bounded runtime signals show?</p></article>
+      <article><span>05</span><h3>Decision</h3><p>Did policy allow promotion, or who accepted which expiring exception?</p></article>
+      <article><span>06</span><h3>Continuity</h3><p>Can deployment verify and monitor the same application and runner bytes?</p></article>
+    </div>
+  </section>
+
+  <section class="flow">
+    <p class="kicker">CONTROLLED PROMOTION</p>
+    <h2>Quarantine → assess → decide → attest → deploy → re-check</h2>
+    <p>The upstream image is never treated as internally trusted merely because it can be pulled. ArtifactGate resolves the digest first, evaluates the application and runner together, fails closed when required evidence is unknown, and promotes the accepted pair into a controlled namespace. Deployment verifies GitHub OIDC-backed attestations and pins both digests.</p>
+  </section>
+
+  <section>
+    <p class="kicker">WHAT TO LOOK OUT FOR</p>
+    <h2>Questions to ask before trusting any third-party image</h2>
+    <div class="checklist">
+      <article><h3>Publisher and upstream build</h3><p>Is the registry owner the expected supplier? Does the supplier sign the image or publish verifiable build provenance? If not, record the gap; digest pinning prevents drift but does not prove publisher identity.</p></article>
+      <article><h3>Mutable references</h3><p>Do not assess <code>latest</code> and later deploy whatever it becomes. Resolve a version to a digest first, and keep every report, SBOM and decision attached to that digest.</p></article>
+      <article><h3>Full workload boundary</h3><p>Check init containers, task runners and sidecars as separate artifacts. Trusting the main application while leaving its helper image mutable creates a gap in the same deployment.</p></article>
+      <article><h3>SBOM quality</h3><p>Check format, component identifiers, versions, dependency relationships, creation time and subject digest. An SBOM is an inventory claim, not proof of completeness or security.</p></article>
+      <article><h3>Vulnerability context</h3><p>Severity alone is not enough. Look for known exploitation, exploitation likelihood, finding age, available fixes and whether required evidence is missing. Do not turn “unknown” into “safe”.</p></article>
+      <article><h3>Runtime and configuration</h3><p>Static analysis cannot show every reachable path or unsafe deployment setting. Review privileges, capabilities, user identity, writable filesystems, exposed ports, secrets and network boundaries.</p></article>
+      <article><h3>Exception quality</h3><p>A waiver should name every accepted finding, explain the need and compensating controls, identify the reviewer, bind to exact digests and expire on a future date.</p></article>
+      <article><h3>Risk after promotion</h3><p>Evidence ages. Re-scan the deployed digest, watch KEV and vulnerability feeds, review expired exceptions and have a rollback or replacement path ready.</p></article>
+    </div>
+  </section>
+
+  <section>
+    <p class="kicker">WHERE TRUST AND RULES ARE DEFINED</p>
+    <h2>Policy is visible, version-controlled and reviewable</h2>
+    <div class="table-scroll"><table class="rule-table">
+      <thead><tr><th scope="col">Control</th><th scope="col">Current rule</th><th scope="col">Source of truth</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">Trusted intake</th><td>Only <code>n8nio/n8n</code> and <code>n8nio/runners</code>; strict <code>x.y.z</code> versions. <code>latest</code> must resolve before use.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/image-ingestion-policy.yml">image-ingestion-policy.yml</a></td></tr>
+        <tr><th scope="row">Vendor identity gap</th><td>Upstream signature verification is currently warning-only, with accepted risk and review date recorded in policy.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/image-ingestion-policy.yml">vendor_signature</a></td></tr>
+        <tr><th scope="row">Automatic gate</th><td>Critical/high findings require review for a KEV match, age ≥30 days, EPSS ≥2%, or unknown required evidence.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/vulnerability-gate-policy.yml">vulnerability-gate-policy.yml</a></td></tr>
+        <tr><th scope="row">Manual exception</th><td>The <code>trusted-promotion</code> environment requires every gated CVE, meaningful justification, compensating controls and a future expiry.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/image-promotion.yml">image-promotion.yml</a></td></tr>
+        <tr><th scope="row">Trusted outputs</th><td>Accepted images go to <code>artifactgate/n8n-trusted</code> and <code>artifactgate/n8n-runners-trusted</code>, with separate attestations.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/docs/signing-and-attestation.md">signing and attestation</a></td></tr>
+        <tr><th scope="row">Deployment admission</th><td>Both attestations must verify against owner <code>llody9977</code>; both images are deployed by digest.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/iac/n8n/install.sh">install.sh</a></td></tr>
+        <tr><th scope="row">Ongoing review</th><td>The latest promoted release is re-scanned weekly; policy regressions open a security issue.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/rescan.yml">rescan.yml</a></td></tr>
+      </tbody>
+    </table></div>
+    <p class="note">Policy changes go through the same protected pull-request path as code. The readable YAML documents intent; the workflow and enrichment script enforce the executable decision.</p>
+  </section>
+
+  <section>
+    <p class="kicker">STANDARDS-INFORMED, NOT CERTIFIED</p>
+    <h2>Grounded in established supply-chain guidance</h2>
+    <div class="standards">
+      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/161/r1/upd1/final">NIST SP 800-161 Rev. 1</a></h3><p>Third-party technology is a supply-chain risk requiring due diligence, assessment, mitigation and continuing oversight.</p></article>
+      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/190/final">NIST SP 800-190</a></h3><p>Informs trusted-image handling, registry controls, vulnerability management and hardened container configuration.</p></article>
+      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/218/final">NIST SP 800-218</a></h3><p>Informs third-party component verification and the collection and protection of release integrity and provenance data.</p></article>
+      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/204/d/final">NIST SP 800-204D</a></h3><p>Frames how provenance, attestations, SBOMs and supply-chain controls fit into CI/CD.</p></article>
+      <article><h3><a href="https://slsa.dev/spec/v1.2/">SLSA v1.2</a></h3><p>Provides a model for provenance and verification. ArtifactGate claims no SLSA level for an upstream image it did not build.</p></article>
+    </div>
+  </section>
+
+  <section id="evidence" class="evidence">
+    <p class="kicker">PUBLIC EVIDENCE</p>
+    <h2>Latest retained promotion</h2>
+    <dl id="release"><dt>Status</dt><dd>Loading release evidence…</dd></dl>
+    <p><a id="release-link" href="https://github.com/llody9977/artifactgate/releases">Open release record</a></p>
+  </section>
+
+  <section>
+    <p class="kicker">VERIFY, DO NOT ASSUME</p>
+    <h2>Bind the decision to the bytes deployed</h2>
+    <pre><code>gh attestation verify oci://IMAGE@sha256:DIGEST -o llody9977</code></pre>
+    <p>Verify both the n8n application and external runner subjects, then deploy both by immutable digest. The promotion attestation proves that ArtifactGate's workflow handled those digests; it does not recreate missing provenance for the vendor's original build.</p>
+  </section>
+
+  <section class="boundary">
+    <p class="kicker">ASSURANCE BOUNDARY</p>
+    <h2>Promotion is a risk decision, not a security certificate</h2>
+    <p>A successful result means the exact pair passed the documented policy or a scoped, justified and expiring exception was approved. It does not mean vulnerability-free, compliant or suitable for every environment. SBOMs and scanner feeds may be incomplete or delayed. Runtime observations cover only exercised smoke-test paths, and “not observed” is not proof that vulnerable code is unreachable.</p>
+  </section>
+
+  <footer>© 2026 <a href="https://github.com/llody9977">llody9977</a> · <a href="https://github.com/llody9977/artifactgate/blob/main/LICENSE">Apache-2.0</a> · Personal and experimental · <a href="https://github.com/llody9977/artifactgate#disclaimer">Full disclaimer</a></footer>
+</main>
+<script>
+fetch('evidence.json').then(response => {
+  if (!response.ok) throw new Error('Evidence unavailable');
+  return response.json();
+}).then(release => {
+  const list = document.querySelector('#release');
+  list.replaceChildren();
+  const rows = [
+    ['Release', release.name || release.tag_name || 'Unnamed release'],
+    ['Published', release.published_at ? new Date(release.published_at).toLocaleString() : 'Unknown']
+  ];
+  for (const [label, value] of rows) {
+    const term = document.createElement('dt');
+    const detail = document.createElement('dd');
+    term.textContent = label;
+    detail.textContent = value;
+    list.append(term, detail);
+  }
+  if (release.html_url) document.querySelector('#release-link').href = release.html_url;
+}).catch(() => {
+  document.querySelector('#release').innerHTML = '<dt>Status</dt><dd>Release evidence is temporarily unavailable.</dd>';
+});
+</script>
+</body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,1 +1,65 @@
-:root{color-scheme:dark;font:16px/1.6 system-ui,sans-serif;background:#0b1014;color:#dce5ea}body{margin:0}main{max-width:850px;margin:auto;padding:8vw 24px}.eyebrow{color:#60d9a8;font:700 12px/1.2 monospace;letter-spacing:.16em}h1{font-size:clamp(3rem,9vw,6.5rem);line-height:.9;margin:.25em 0}h2{font-size:1.2rem}.lede{font-size:1.3rem;color:#aebdc5;max-width:680px}section{border-top:1px solid #29343a;margin-top:3rem;padding-top:1.5rem}dl{display:grid;grid-template-columns:110px 1fr}dt{color:#80919a}dd{margin:0}a{color:#60d9a8}pre{padding:1rem;background:#121a1f;overflow:auto}footer{margin-top:4rem;color:#80919a;font-size:.85rem}
+:root {
+  color-scheme: dark;
+  font: 16px/1.65 Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  background: #080d10;
+  color: #dce7eb;
+  --ink: #dce7eb;
+  --muted: #91a4ad;
+  --line: #263239;
+  --panel: #0e161a;
+  --accent: #62e6ac;
+  --accent-dark: #173d30;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; background: radial-gradient(circle at 85% 5%, #123027 0, transparent 25rem), #080d10; }
+main { max-width: 1040px; margin: auto; padding: 5rem 24px; }
+.hero { min-height: 72vh; display: flex; flex-direction: column; justify-content: center; }
+.eyebrow, .kicker { color: var(--accent); font: 700 .75rem/1.3 ui-monospace, SFMono-Regular, monospace; letter-spacing: .16em; }
+.kicker { margin-bottom: .4rem; }
+h1 { max-width: 900px; font-size: clamp(3.5rem, 9vw, 7.5rem); letter-spacing: -.06em; line-height: .88; margin: .22em 0; }
+h2 { max-width: 760px; font-size: clamp(1.8rem, 4vw, 3rem); letter-spacing: -.03em; line-height: 1.1; margin: .25rem 0 1.25rem; }
+h3 { font-size: 1rem; margin: .35rem 0; }
+.lede { font-size: clamp(1.15rem, 2.5vw, 1.55rem); color: #b9c8ce; max-width: 760px; }
+.principle { max-width: 740px; border-left: 3px solid var(--accent); padding: .5rem 0 .5rem 1.2rem; color: var(--muted); }
+.actions { display: flex; gap: 1.25rem; align-items: center; margin-top: 1.5rem; }
+.button { background: var(--accent); color: #07110d; padding: .65rem 1rem; text-decoration: none; font-weight: 750; border-radius: 3px; }
+section { border-top: 1px solid var(--line); margin-top: 5rem; padding-top: 2rem; }
+section > p { max-width: 790px; }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); margin-top: 2rem; }
+.grid article { background: var(--panel); padding: 1.4rem; }
+.grid span { font: 700 .75rem ui-monospace, SFMono-Regular, monospace; color: var(--accent); }
+.grid p, .standards p { color: var(--muted); font-size: .94rem; margin-bottom: 0; }
+.standards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+.standards article { border: 1px solid var(--line); padding: 1.25rem; background: linear-gradient(145deg, var(--panel), transparent); }
+.checklist { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0 2rem; }
+.checklist article { border-top: 1px solid var(--line); padding: 1rem 0; }
+.checklist p { color: var(--muted); margin: .25rem 0; }
+.table-scroll { overflow-x: auto; }
+.rule-table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); font-size: .94rem; }
+.rule-table th, .rule-table td { padding: 1rem; text-align: left; vertical-align: top; border-top: 1px solid var(--line); }
+.rule-table thead { background: var(--accent-dark); color: var(--ink); }
+.rule-table thead th { border-top: 0; }
+.rule-table tbody th { min-width: 145px; }
+.rule-table td:last-child { min-width: 165px; }
+.rule-table code, .checklist code { color: #c9fbe5; }
+.note { color: var(--muted); font-size: .9rem; }
+.flow { padding: 2rem; background: linear-gradient(110deg, var(--accent-dark), transparent 70%); border-top: 2px solid var(--accent); }
+.evidence { border: 1px solid var(--line); padding: 2rem; background: var(--panel); }
+.boundary { border-top-color: #9d7043; }
+dl { display: grid; grid-template-columns: 120px 1fr; max-width: 700px; }
+dt { color: var(--muted); }
+dd { margin: 0; }
+a { color: var(--accent); text-underline-offset: .18em; }
+pre { padding: 1rem 1.25rem; background: #030607; border: 1px solid var(--line); overflow: auto; }
+footer { margin-top: 5rem; padding-top: 1.5rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .85rem; }
+
+@media (max-width: 720px) {
+  main { padding-top: 3rem; }
+  .hero { min-height: auto; padding: 4rem 0; }
+  .grid, .standards, .checklist { grid-template-columns: 1fr; }
+  .flow, .evidence { padding: 1.4rem; }
+  .actions { align-items: flex-start; flex-direction: column; }
+  dl { grid-template-columns: 90px 1fr; }
+}


### PR DESCRIPTION
## What changed

- frame ArtifactGate as evidence-based admission control for third-party containers
- explain provenance, SBOM, vulnerability, runtime, exception and continuity boundaries
- map the design to NIST SP 800-161, SP 800-190, SP 800-218, SP 800-204D and SLSA v1.2 without making compliance claims
- add an operator checklist covering what to look out for in third-party images
- show the actual trusted sources, gate thresholds, exception rules, trusted outputs and source-of-truth files
- redesign the GitHub Pages evidence site for desktop and mobile

## Why

The previous copy described the mechanics but did not clearly explain the risk problem, how trust is earned, or where operators can inspect and change the rules. The new framing makes the project useful as both a reference implementation and a transparent decision record.

## Validation

- `npx --yes html-validate@latest site/index.html`
- `git diff --check`
- `python3 .github/scripts/test_validate_compose.py`
- `bash .github/scripts/test_tracee_merge.sh`
- desktop and mobile headless Chrome visual review