### PR TITLE
fix: resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python3 .github/scripts/test_validate_compose.py
 
       - name: IaC Scan (Checkov)
-        uses: bridgecrewio/checkov-action@2fd3901c8feb52417f27f0d9800259a106c1ec1e # master
+        uses: bridgecrewio/checkov-action@7b972723c44fb3d256283fac96fae5d7c1894bb7 # master
         with:
           directory: iac/n8n
           quiet: true

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -243,7 +243,7 @@ jobs:
           mv trivy-report.combined.json trivy-report.tracee.json
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
@@ -447,7 +447,7 @@ jobs:
         with:
           name: scan-report-${{ needs.scan-images.outputs.resolved_version }}
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -476,7 +476,7 @@ jobs:
           echo "runner_digest=$RUNNER_GHCR_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-trusted
           subject-digest: ${{ steps.docker_push.outputs.digest }}
@@ -484,7 +484,7 @@ jobs:
           show-summary: false
 
       - name: Attest task runner provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-runners-trusted
           subject-digest: ${{ steps.docker_push.outputs.runner_digest }}
@@ -504,7 +504,7 @@ jobs:
           echo "SBOM generated: $(jq '.packages | length' sbom.spdx.json) packages"
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-trusted
           subject-digest: ${{ steps.docker_push.outputs.digest }}
@@ -513,7 +513,7 @@ jobs:
           show-summary: false
 
       - name: Attest task runner SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-runners-trusted
           subject-digest: ${{ steps.docker_push.outputs.runner_digest }}
@@ -527,7 +527,7 @@ jobs:
           echo "✅ **SLSA Build Provenance** and **SBOM** have been securely attested to the image digest \`${{ steps.docker_push.outputs.digest }}\`." >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Release with rollback info
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2
         with:
           files: |
             ./sbom.spdx.json
@@ -639,7 +639,7 @@ jobs:
             exit 1
           fi
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -668,7 +668,7 @@ jobs:
           echo "runner_digest=$RUNNER_GHCR_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-trusted
           subject-digest: ${{ steps.docker_push.outputs.digest }}
@@ -676,7 +676,7 @@ jobs:
           show-summary: false
 
       - name: Attest task runner provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-runners-trusted
           subject-digest: ${{ steps.docker_push.outputs.runner_digest }}
@@ -694,7 +694,7 @@ jobs:
           echo "SBOM generated: $(jq '.packages | length' sbom.spdx.json) packages"
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-trusted
           subject-digest: ${{ steps.docker_push.outputs.digest }}
@@ -703,7 +703,7 @@ jobs:
           show-summary: false
 
       - name: Attest task runner SBOM
-        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}/n8n-runners-trusted
           subject-digest: ${{ steps.docker_push.outputs.runner_digest }}
@@ -717,7 +717,7 @@ jobs:
           echo "✅ **SLSA Build Provenance** and **SBOM** have been securely attested to the image digest \`${{ steps.docker_push.outputs.digest }}\`." >> $GITHUB_STEP_SUMMARY
 
       - name: Create GitHub Release with rollback info
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2
         with:
           files: |
             ./sbom.spdx.json

--- a/.github/workflows/rescan.yml
+++ b/.github/workflows/rescan.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y trivy
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -275,7 +275,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: hashFiles(format('sarifs/rescan-{0}.sarif', matrix.version)) != ''
-        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: "sarifs/rescan-${{ matrix.version }}.sarif"
           category: "rescan-${{ matrix.version }}"


### PR DESCRIPTION
This PR updates GitHub Actions in CI, image-promotion, and rescan workflows to their latest Node 24 compatible versions, resolving deprecation warnings.