### PR TITLE
fix: ZAP enforcement, runtime observation renames, control inventory, and standards mappings

### DIFF
--- a/.github/scripts/enrich_findings.py
+++ b/.github/scripts/enrich_findings.py
@@ -128,7 +128,7 @@ def main():
         epss_score = epss_scores.get(cve_id)
         epss_label = epss_risk(epss_score)
         epss_percent = round(epss_score * 100, 2) if epss_score is not None else None
-        reachable = vuln.get("Reachable")
+        reachable = vuln.get("RuntimeObserved")
 
         gate_decision = "AUTO_ALLOWED"
         gate_reasons = []
@@ -159,9 +159,13 @@ def main():
                 gate_decision = "MANUAL_REVIEW"
                 gate_reasons.append("epss_unknown")
 
+            if reachable is True:
+                gate_decision = "MANUAL_REVIEW"
+                gate_reasons.append("runtime_observed")
+
             if reachable is None:
                 gate_decision = "MANUAL_REVIEW"
-                gate_reasons.append("reachability_unknown")
+                gate_reasons.append("runtime_observation_unknown")
 
             if gate_decision == "MANUAL_REVIEW":
                 summary["manual_review_count"] += 1

--- a/.github/scripts/generate_summary.py
+++ b/.github/scripts/generate_summary.py
@@ -109,7 +109,7 @@ def main():
     lines.append("")
 
     if vulns:
-        lines.append("| CVE | Severity | Published | Age | Package | Version | Fixed In | Reachability | KEV | EPSS | EPSS Risk | Gate |")
+        lines.append("| CVE | Severity | Published | Age | Package | Version | Fixed In | Runtime Obs. | KEV | EPSS | EPSS Risk | Gate |")
         lines.append("| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |")
         for v in vulns:
             cve_id = v.get("VulnerabilityID", "")
@@ -120,7 +120,7 @@ def main():
             pkg = v.get("PkgName", "")
             installed = v.get("InstalledVersion", "")
             fixed = v.get("FixedVersion") or "None"
-            reachable = v.get("Reachability", "Unknown")
+            reachable = v.get("RuntimeObservation", "Unknown")
             kev = "\u2705 Yes" if v.get("KevHit") or cve_id in kev_ids else "No"
             epss = fmt_epss(v.get("EpssPercent"))
             epss_risk = v.get("EpssRisk", "-")

--- a/.github/scripts/generate_vex.py
+++ b/.github/scripts/generate_vex.py
@@ -38,7 +38,7 @@ def main():
             vuln_id = vul.get("VulnerabilityID")
             pkg_name = vul.get("PkgName")
             gate_decision = vul.get("GateDecision")
-            reachable = vul.get("Reachability", "Unknown")
+            reachable = vul.get("RuntimeObservation", "Unknown")
             
             if not vuln_id:
                 continue

--- a/.github/scripts/merge_tracee_reachability.py
+++ b/.github/scripts/merge_tracee_reachability.py
@@ -151,28 +151,44 @@ def main():
     package_paths = load_package_paths(package_tsv)
     observed_paths, matched_events = load_observed_paths(tracee_events, target_container_id)
 
-    reachable_count = 0
+    observed_vulnerabilities_count = 0
+    observed_packages = {pkg for pkg, files in package_paths.items() if files.intersection(observed_paths)}
+    packages_observed_count = len(observed_packages)
+    packages_total_count = len(package_paths)
+    coverage_ratio = packages_observed_count / packages_total_count if packages_total_count > 0 else 0.0
+
     for result in report.get("Results", []):
         for vuln in result.get("Vulnerabilities") or []:
             package_name = vuln.get("PkgName", "")
             candidates = package_paths.get(package_name, set())
             evidence = sorted(path for path in candidates if path in observed_paths)
-            reachable = True if evidence else (False if candidates and matched_events > 0 else None)
-            if reachable is True:
-                reachable_count += 1
-            vuln["Reachable"] = reachable
-            vuln["Reachability"] = (
-                "Observed" if reachable is True
-                else "Not observed" if reachable is False
+            
+            # Default logic: True if loaded, False if not loaded (provided some events matched), None if no package files mapped
+            observed = True if evidence else (False if candidates and matched_events > 0 else None)
+            
+            # Downgrade rule: if package-level runtime observation coverage is < 20%, downgrade False to None (Unknown)
+            # because we cannot reliably assert 'Not observed' without a representative test run.
+            if observed is False and coverage_ratio < 0.20:
+                observed = None
+
+            if observed is True:
+                observed_vulnerabilities_count += 1
+            vuln["RuntimeObserved"] = observed
+            vuln["RuntimeObservation"] = (
+                "Observed" if observed is True
+                else "Not observed" if observed is False
                 else "Unknown"
             )
             vuln["ReachabilityEvidence"] = evidence[:5]
 
-    report["ReachabilitySummary"] = {
+    report["RuntimeObservationSummary"] = {
         "tracee_runtime_signal": "package_file_exec_or_load",
         "observed_paths_count": len(observed_paths),
         "matched_event_count": matched_events,
-        "reachable_vulnerability_count": reachable_count,
+        "packages_observed_count": packages_observed_count,
+        "packages_total_count": packages_total_count,
+        "packages_coverage_pct": round(coverage_ratio * 100, 2),
+        "observed_vulnerability_count": observed_vulnerabilities_count,
         "limitations": "A negative result means only that mapped package files were not observed during this smoke test; it does not prove code is unreachable.",
         "target_container_id": target_container_id[:12],
     }
@@ -185,7 +201,7 @@ def main():
         "Merged Tracee reachability:"
         f" {len(observed_paths)} observed paths,"
         f" {matched_events} matched events,"
-        f" {reachable_count} reachable vulnerabilities"
+        f" {observed_vulnerabilities_count} observed vulnerabilities"
     )
 
 

--- a/.github/scripts/run_tracee_reachability.sh
+++ b/.github/scripts/run_tracee_reachability.sh
@@ -76,12 +76,26 @@ done
 
 # DAST: Run OWASP ZAP Baseline Scan against the running container
 echo "Running ZAP Baseline Scan against http://127.0.0.1:${HOST_PORT} ..."
-# We use -u root so ZAP can write zap-report.html directly to the output directory map without permission errors
+# We use -u root so ZAP can write zap-report.html/json directly to the output directory map without permission errors
+# We generate both HTML and JSON reports to support human auditing and automated policy gating
 docker run -u root --rm --network host \
   -v "$OUTPUT_DIR:/zap/wrk/:rw" \
   zaproxy/zap-stable:2.17.0@sha256:8d387b1a63e3425beef4846e39719f5af2a787753af2d8b6558c6257d7a577a2 zap-baseline.py \
   -t "http://127.0.0.1:${HOST_PORT}" \
-  -r zap-report.html -I >/dev/null 2>&1 || echo "ZAP Baseline finished"
+  -r zap-report.html -J zap-report.json -I >/dev/null 2>&1 || echo "ZAP Baseline scan completed"
+
+# Parse ZAP JSON report to enforce a hard block on any HIGH risk alerts
+if [ -f "$OUTPUT_DIR/zap-report.json" ]; then
+  HIGH_ALERTS=$(jq '[.site[].alerts[]? | select(.riskcode=="3")] | length' "$OUTPUT_DIR/zap-report.json" || echo "0")
+  if [ "$HIGH_ALERTS" -gt 0 ]; then
+    echo "❌ DAST Error: OWASP ZAP detected $HIGH_ALERTS HIGH risk alert(s) on the running container. Failing closed." >&2
+    exit 1
+  else
+    echo "✅ DAST Verification: OWASP ZAP scan finished with zero HIGH risk alerts."
+  fi
+else
+  echo "⚠️ DAST Warning: OWASP ZAP failed to generate a JSON report."
+fi
 
 docker exec "$CONTAINER_NAME" /bin/sh -lc 'command -v node >/dev/null 2>&1 && node -p process.version >/dev/null' || true
 docker exec "$CONTAINER_NAME" /bin/sh -lc 'test -f /usr/local/bin/n8n && /usr/local/bin/n8n --help >/dev/null 2>&1' || true

--- a/.github/scripts/test_tracee_merge.sh
+++ b/.github/scripts/test_tracee_merge.sh
@@ -82,13 +82,13 @@ GITHUB_STEP_SUMMARY="$summary_path" python3 .github/scripts/generate_summary.py 
   "$tmpdir/kev.json" \
   "fixture"
 
-jq -e '.ReachabilitySummary.matched_event_count == 1' "$tmpdir/trivy-report.tracee.json" > /dev/null
-jq -e '.ReachabilitySummary.reachable_vulnerability_count == 1' "$tmpdir/trivy-report.tracee.json" > /dev/null
-jq -e '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "CVE-2024-1111") | .Reachability] | any(. == "Observed")' "$tmpdir/trivy-report.enriched.json" > /dev/null
-jq -e '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "CVE-2024-2222") | .Reachability] | any(. == "Not observed")' "$tmpdir/trivy-report.enriched.json" > /dev/null
+jq -e '.RuntimeObservationSummary.matched_event_count == 1' "$tmpdir/trivy-report.tracee.json" > /dev/null
+jq -e '.RuntimeObservationSummary.observed_vulnerability_count == 1' "$tmpdir/trivy-report.tracee.json" > /dev/null
+jq -e '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "CVE-2024-1111") | .RuntimeObservation] | any(. == "Observed")' "$tmpdir/trivy-report.enriched.json" > /dev/null
+jq -e '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "CVE-2024-2222") | .RuntimeObservation] | any(. == "Not observed")' "$tmpdir/trivy-report.enriched.json" > /dev/null
 jq -e '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "CVE-2024-3333") | .GateDecision] | any(. == "MANUAL_REVIEW")' "$tmpdir/trivy-report.enriched.json" > /dev/null
 jq -e '.AnalysisSummary.unknown_age_critical_high_count == 1' "$tmpdir/trivy-report.enriched.json" > /dev/null
-grep -q "Reachability" "$summary_path"
+grep -q "Runtime Obs." "$summary_path"
 
 python3 .github/scripts/generate_vex.py "$tmpdir/trivy-report.enriched.json" > "$tmpdir/vex.json"
 jq -e '[.statements[] | select(.vulnerability.name == "CVE-2024-2222") | .status] | any(. == "under_investigation")' "$tmpdir/vex.json" >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,10 @@ jobs:
         run: |
           python3 .github/scripts/generate_summary.py trivy-report.enriched.json kev.json ci-tracee-test
 
-          jq -e '.ReachabilitySummary.matched_event_count > 0' trivy-report.tracee.json > /dev/null
-          jq -e '[.Results[]?.Vulnerabilities[]? | has("Reachable")] | all' trivy-report.enriched.json > /dev/null
-          jq -e '[.Results[]?.Vulnerabilities[]? | .Reachability] | length > 0 and all(. == "Observed" or . == "Not observed" or . == "Unknown")' trivy-report.enriched.json > /dev/null
-          grep -q "Reachability" "$GITHUB_STEP_SUMMARY"
+          jq -e '.RuntimeObservationSummary.matched_event_count > 0' trivy-report.tracee.json > /dev/null
+          jq -e '[.Results[]?.Vulnerabilities[]? | has("RuntimeObserved")] | all' trivy-report.enriched.json > /dev/null
+          jq -e '[.Results[]?.Vulnerabilities[]? | .RuntimeObservation] | length > 0 and all(. == "Observed" or . == "Not observed" or . == "Unknown")' trivy-report.enriched.json > /dev/null
+          grep -q "Runtime Obs." "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Tracee integration artifacts
         if: always()

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -239,8 +239,8 @@ jobs:
             "$(cat tracee-output/target-container-id.txt)" \
             trivy-report.tracee.json
           jq '(.Results[]? | .Target) |= ("n8n-runners:" + .) |
-              (.Results[]?.Vulnerabilities[]? | .Reachable)=null |
-              (.Results[]?.Vulnerabilities[]? | .Reachability)="Unknown" |
+              (.Results[]?.Vulnerabilities[]? | .RuntimeObserved)=null |
+              (.Results[]?.Vulnerabilities[]? | .RuntimeObservation)="Unknown" |
               (.Results[]?.Vulnerabilities[]? | .ReachabilityEvidence)=[]' \
               trivy-report.runner.json > trivy-report.runner.annotated.json
           jq -s '.[0].Results += (.[1].Results // []) | .[0]' \

--- a/.github/workflows/rescan.yml
+++ b/.github/workflows/rescan.yml
@@ -143,6 +143,11 @@ jobs:
           mkdir -p "tracee-$VERSION"
           .github/scripts/collect_package_files.sh "$IMAGE" "rescan-$VERSION.raw.json" "tracee-$VERSION/package-files.tsv"
           .github/scripts/run_tracee_reachability.sh "$IMAGE" "$PWD/tracee-$VERSION" "tracee-rescan-$VERSION-${{ github.run_id }}" "${{ env.TRACEE_HOST_PORT }}" "${{ env.TRACEE_CONTAINER_PORT }}"
+          if [ -f "tracee-$VERSION/zap-report.html" ]; then
+            echo "✅ OWASP ZAP DAST scan completed successfully. Report saved at tracee-$VERSION/zap-report.html"
+          else
+            echo "⚠️ OWASP ZAP DAST scan did not generate a report."
+          fi
           python3 .github/scripts/merge_tracee_reachability.py \
             "rescan-$VERSION.raw.json" \
             "tracee-$VERSION/package-files.tsv" \
@@ -150,8 +155,8 @@ jobs:
             "$(cat "tracee-$VERSION/target-container-id.txt")" \
             "rescan-$VERSION.tracee.json"
           jq '(.Results[]? | .Target) |= ("n8n-runners:" + .) |
-              (.Results[]?.Vulnerabilities[]? | .Reachable)=null |
-              (.Results[]?.Vulnerabilities[]? | .Reachability)="Unknown" |
+              (.Results[]?.Vulnerabilities[]? | .RuntimeObserved)=null |
+              (.Results[]?.Vulnerabilities[]? | .RuntimeObservation)="Unknown" |
               (.Results[]?.Vulnerabilities[]? | .ReachabilityEvidence)=[]' \
               "rescan-$VERSION.runner.json" > "rescan-$VERSION.runner.annotated.json"
           jq -s '.[0].Results += (.[1].Results // []) | .[0]' \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ArtifactGate is designed to answer six questions before deployment:
 | **Source** — Did this come from an allowed upstream? | source allowlist and version intake policy |
 | **Identity** — Which exact bytes were assessed? | OCI digest resolution and digest pinning |
 | **Composition** — What is declared to be inside? | SPDX SBOM and machine-readable OpenVEX statement generation and attestation |
-| **Risk** — What security signals are known now? | vulnerability, malware, secret, licence, KEV, EPSS, age, OpenVEX and bounded runtime checks |
+| **Risk** — What security signals are known now? | vulnerability, malware, secret, licence, KEV, EPSS, age, OpenVEX and runtime observation |
 | **Decision** — Why was it promoted? | policy gate or explicit, scoped, expiring waiver and cryptographically signed OpenVEX document |
 | **Continuity** — Are we deploying and monitoring the same artifact? | keyless promotion attestation, verification before deployment and scheduled re-scan |
 
@@ -33,7 +33,7 @@ These are complementary controls. Provenance is not an SBOM, an SBOM is not a vu
 
 - allowlists the upstream source image and enforces semver-style version intake
 - resolves and scans immutable application and runner digests
-- enriches findings with `KEV`, `EPSS`, CVE age, and runtime reachability context
+- enriches findings with `KEV`, `EPSS`, CVE age, and bounded runtime observation
 - promotes an approved application and runner pair to GHCR
 - attests provenance and SBOM data for the promoted artifact
 - re-scans the latest promoted release on a schedule
@@ -76,7 +76,7 @@ flowchart TD
     A["Promotion request or weekly version check"] --> B["Allowlist and semver policy"]
     B --> C["Resolve immutable digest"]
     C --> D["Trivy, ClamAV, Tracee, and ZAP checks"]
-    D --> E["KEV, EPSS, age, and reachability enrichment"]
+    D --> E["KEV, EPSS, age, and runtime observation enrichment"]
     E --> F{"Approval gate"}
     F -->|Lower-risk| G["Auto-promote to GHCR"]
     F -->|Higher-risk| H["Manual approval"]

--- a/docs/architecture-and-trust.md
+++ b/docs/architecture-and-trust.md
@@ -29,20 +29,27 @@ digest establishes byte identity; the SBOM describes known composition; scanning
 enrichment support a risk decision; the ArtifactGate attestation records the promotion
 path; and runtime hardening limits impact. None is a substitute for the others.
 
-## Threat Model Mapping
+## Control Inventory and Threat Mapping
 
-| Threat pattern | Why it matters here | Primary control in this repo |
-| :--- | :--- | :--- |
-| Dependency chain abuse | A trusted vendor image can still introduce risky or newly vulnerable components | digest pinning, Trivy scan, KEV/EPSS/age enrichment |
-| Artifact substitution or tag drift | A mutable upstream tag can change without notice | resolve and pin immutable digest before promotion |
-| Prohibitive licences | Vendor images may introduce strict copyleft licences | Trivy licence reporting for human review |
-| Runtime misconfigurations | Static scans miss exposed runtime HTTP flaws | OWASP ZAP baseline DAST during smoke run |
-| IaC and script weaknesses | Deployment files can undermine otherwise good image controls | Checkov and Shellcheck in CI |
-| Insufficient flow control | Higher-risk images should not move through the same path as cleaner ones | manual approval via `trusted-promotion` |
-| Weak artifact integrity evidence | Teams need proof, not only a passing scan | provenance, SBOM, and machine-readable OpenVEX attestation |
-| Weak pipeline identity model | Long-lived publish credentials expand exposure | ephemeral `GITHUB_TOKEN` and OIDC-backed attestation |
-| Insufficient day-2 monitoring | Risk changes after promotion | scheduled re-scan of the latest promoted release |
-| Runtime over-privilege | A compromised workload can still do damage after deploy | hardened Docker runtime settings |
+The following table maps the specific security controls implemented in this repository to the risks they address, their execution context, enforcement behavior, and alignment with industry standards.
+
+| Control / Verification | Risk Addressed | Function | Control Point | Enforcement | Source File | Standards Mapping |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Source Ingestion Allowlist** | Rogue tag intake & untrusted vendors | Preventive | Intake | **Blocking** | [`image-ingestion-policy.yml`](/policy/image-ingestion-policy.yml) | OWASP CICD-SEC-3<br>NIST SSDF PO.1.3, PW.4.1<br>NIST SP 800-53 SR-3 |
+| **OCI Digest Resolution** | Tag drift & tag poisoning | Preventive | Intake | **Blocking** | [`image-promotion.yml`](/.github/workflows/image-promotion.yml) | OWASP CICD-SEC-3<br>NIST SSDF PW.4.4<br>NIST SP 800-53 SR-11 / CM-14 |
+| **Trivy Malware Scan** | Malware injection in vendor layers | Detective | Promotion Gate | **Blocking** | [`image-promotion.yml`](/.github/workflows/image-promotion.yml#L189) | OWASP CICD-SEC-3<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **Trivy Secret Scan** | Embedded credentials & API keys | Preventive | Promotion Gate | **Blocking** | [`image-promotion.yml`](/.github/workflows/image-promotion.yml#L179) | OWASP CICD-SEC-3<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **Trivy Licence Scan** | Copyleft licence liabilities | Detective | Promotion Gate | Advisory | [`image-promotion.yml`](/.github/workflows/image-promotion.yml#L202) | OWASP CICD-SEC-3<br>NIST SSDF PO.3.2<br>NIST SP 800-53 SR-3 |
+| **OWASP ZAP DAST Scan** | Runtime HTTP flaws & misconfigurations | Preventive | Promotion Gate | **Blocking** | [`run_tracee_reachability.sh`](/.github/scripts/run_tracee_reachability.sh#L77-L85) | OWASP CICD-SEC-3<br>NIST SSDF RV.1.1<br>NIST SP 800-53 SR-3 |
+| **Tracee eBPF Observation** | Socially engineered logic bombs & call-graph loading | Detective | Promotion Gate | **Blocking** (Gated on `RuntimeObserved` / Coverage) | [`merge_tracee_reachability.py`](/.github/scripts/merge_tracee_reachability.py) | OWASP CICD-SEC-3<br>NIST SSDF RV.1.3<br>NIST SP 800-53 SR-11 |
+| **Age, KEV & EPSS Enrichment** | Active CVE exploitation & zero-days | Preventive | Promotion Gate | **Blocking** | [`enrich_findings.py`](/.github/scripts/enrich_findings.py) | OWASP CICD-SEC-3<br>NIST SSDF RV.1.1<br>NIST SP 800-53 SR-3 |
+| **Waiver Expiry Enforcement** | Waiver & Exception decay | Preventive | Exception / Waiver | **Blocking** | [`image-promotion.yml`](/.github/workflows/image-promotion.yml) | OWASP CICD-SEC-1<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **GitHub Actions SHA Pinning** | Third-party action dependency hijacking | Preventive | Build / Pipeline | **Blocking** | All workflow manifests | OWASP CICD-SEC-3<br>NIST SSDF PW.4.4<br>NIST SP 800-53 SR-3 |
+| **Scoped Token Permissions** | CI runner takeover & token theft | Preventive | Build / Pipeline | **Blocking** | Workflow permissions blocks | OWASP CICD-SEC-6<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **OIDC Provenance & SBOM Attestation** | Namespace compromise & image swapping | Preventive | Attestation / Deploy | **Blocking** | [`install.sh`](/iac/n8n/install.sh) | OWASP CICD-SEC-3<br>NIST SSDF PW.4.4<br>NIST SP 800-53 SR-4 / CM-14 |
+| **Checkov & ShellCheck** | IaC misconfiguration & privilege escalation | Preventive | Build (PR Merge) | **Blocking** | [`ci.yml`](/.github/workflows/ci.yml) | OWASP CICD-SEC-1<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **CodeQL Scan** | Local code vulnerabilities | Detective | Build (PR Merge) | **Blocking** | [`codeql.yml`](/.github/workflows/codeql.yml) | OWASP CICD-SEC-1<br>NIST SSDF PW.4.1<br>NIST SP 800-53 SR-3 |
+| **Scheduled Re-Scanning** | Post-promotion security decay | Corrective | Continuous | **Blocking** (Opens Issues) | [`rescan.yml`](/.github/workflows/rescan.yml) | OWASP CICD-SEC-9<br>NIST SSDF RV.1.1<br>NIST SP 800-53 SR-11 |
 
 ## Pipeline Architecture
 
@@ -121,52 +128,44 @@ Examples in this repo:
 
 ### NIST SP 800-218 (SSDF)
 
-Useful here for third-party component verification and collecting provenance data for
-release components. ArtifactGate is a consumer and promoter of the example vendor image;
-it does not claim to implement the vendor's development lifecycle.
+Useful here for third-party component verification and collecting provenance data for release components. ArtifactGate aligns with specific practices for the consumer/promoter phase:
+- **PO.1.3 & PW.4.1**: Specifying and validating third-party software components (Source allowlists, Trivy malware/secret/vulnerability checks).
+- **PO.3.2**: Evaluating licensing risk (Trivy licence reporting).
+- **PW.4.4**: Verifying the integrity of acquired software (Digest pinning, OIDC provenance verification).
+- **RV.1.1 & RV.1.3**: Bounded runtime observation and vulnerability checking (Tracee eBPF monitoring, OWASP ZAP DAST scans).
 
 ### OWASP Top 10 CI/CD Security Risks
 
 Useful here for framing the pipeline as an attack surface instead of only a delivery mechanism.
-
-Examples in this repo:
-
-- workflow separation
-- manual approval for higher-risk paths
-- digest pinning
-- artifact evidence and release traceability
+- **CICD-SEC-1 (PPE)**: Defended via branch protections and required code review on workflows and policies.
+- **CICD-SEC-3 (Dependency Chain Abuse)**: Prevented via digest pinning, Trivy scanning, and Actions commit SHA pinning.
+- **CICD-SEC-6 (Insufficient Credential Hygiene)**: Mitigated by using ephemeral GitHub OIDC tokens instead of static credentials.
+- **CICD-SEC-9 (Inadequate System Monitoring)**: Addressed via weekly scheduled re-scans of promoted container digests.
 
 ### NIST SP 800-53
 
-Useful here for the control vocabulary behind access control, integrity, auditability, and least privilege.
-
-Examples in this repo:
-
-- policy-as-code
-- approval gates
-- audit-friendly release evidence
-- hardened runtime defaults
+Useful here for specifying supply-chain and component controls:
+- **SR-3 (Supply Chain Controls)**: Intake allowed list and Trivy scanners for secrets, malware, and CVEs.
+- **SR-4 (Provenance)**: Ephemeral Actions OIDC provenance signing.
+- **SR-11 (Component Authenticity)**: Enforced via cryptographic verification of build-time OIDC attestations at deploy.
+- **CM-14 (Signed Components)**: Verification of container image signatures and machine-readable OpenVEX documents.
 
 ### NIST SP 800-204D
 
-Useful here for understanding how supply-chain controls fit into a DevSecOps pipeline.
+Useful here for understanding how supply-chain controls fit into a DevSecOps pipeline:
+- Policy-driven intake rules and gates.
+- Artifact-centric promotion decisions.
+- Ongoing re-scan of active promoted releases.
 
-Examples in this repo:
+### SLSA (Supply-chain Levels for Software Artifacts)
 
-- policy-driven intake
-- artifact-centric promotion decisions
-- ongoing re-scan of the active promoted release
+ArtifactGate's promotion provenance exhibits **SLSA Build L2/L3 properties** for the promotion step (hosted, ephemeral build platform with OIDC identities). It makes no SLSA claim about the upstream vendor's original build, which it did not perform and cannot verify.
 
-### SLSA
+### EU Cyber Resilience Act (CRA) & NTIA Minimum Elements
 
-Useful here for reasoning about provenance, artifact integrity, and promotion trust.
-
-Examples in this repo:
-
-- immutable digest pinning
-- provenance attestation
-- SBOM attestation
-- release evidence tied to the promoted image digest
+Useful here for ensuring compliance with emerging digital supply chain regulations:
+- **NTIA Minimum Elements for an SBOM**: Enforced via Trivy-generated SPDX SBOMs containing component details, dependencies, and relationship links.
+- **EU CRA (Vulnerability Disclosure and VEX)**: ArtifactGate generates machine-readable **OpenVEX** documents mapping to vulnerability scanning data, establishing an automated mechanism to declare product vulnerability status.
 
 ## Docker Hardening
 

--- a/docs/gate-policy.md
+++ b/docs/gate-policy.md
@@ -25,32 +25,32 @@ This repository uses a richer gate so promotion decisions are not based on sever
 
 Age adds a tolerance-window signal. A fresh issue and a long-standing unresolved issue should not always be treated the same way.
 
-### Tracee Reachability
+### Runtime Observation
 
-Tracee contributes bounded runtime context by showing whether mapped package files were observed during a smoke run. “Not observed” does not prove that vulnerable code is unreachable.
+Tracee contributes bounded runtime context by showing whether mapped package files were observed loading during a container smoke run. “Not observed” does not prove that vulnerable code is unreachable.
 
-Current status:
-
-- reachability is reported as analyst context
-- missing collection or mapping is represented as unknown and fails closed for critical/high findings
-- it is not the sole approval signal
+Our runtime observation policy enforces three key principles:
+1. **Observed Escalation**: If a package containing a `CRITICAL` or `HIGH` vulnerability is observed loading during the smoke run (`Observed`), the finding is escalated to `Manual review` with the reason `runtime_observed`.
+2. **Coverage Downgrade**: The smoke test must exercise at least 20% of all mapped packages. If package-level coverage falls below 20%, all `Not observed` findings are downgraded to `Unknown`, forcing them to fail closed (requiring manual review).
+3. **No De-escalation**: A vulnerability that is already flagged for manual review (due to age, KEV, or EPSS) is never downgraded to auto-allowed because it was not observed loading.
 
 ## Gate Policy
 
 For `CRITICAL` and `HIGH` findings:
 
-| Finding severity | KEV | EPSS | Age | Reachability | Action |
+| Finding severity | KEV | EPSS | Age | Runtime Observation | Action |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | `CRITICAL` / `HIGH` | Yes | Any | Any | Any | Manual review |
 | `CRITICAL` / `HIGH` | No | Above repo threshold | Any | Any | Manual review |
 | `CRITICAL` / `HIGH` | No | Below repo threshold | At least 30 days | Any | Manual review |
 | `CRITICAL` / `HIGH` | No | Unknown | Any | Any | Manual review |
 | `CRITICAL` / `HIGH` | No | Low | Unknown | Any | Manual review |
+| `CRITICAL` / `HIGH` | No | Low | Any | Observed | Manual review |
 | `CRITICAL` / `HIGH` | No | Low | Any | Unknown | Manual review |
-| `CRITICAL` / `HIGH` | No | Below threshold | Under 30 days | Any | Auto-allowed |
+| `CRITICAL` / `HIGH` | No | Below threshold | Under 30 days | Not Observed (Coverage &ge; 20%) | Auto-allowed |
 | `MEDIUM` / `LOW` / `UNKNOWN` | No | Any | Any | Any | Reported, but does not directly trigger manual approval |
 
-Unknown evidence is not converted to a zero score or a negative reachability claim. Critical/high findings require manual review whenever age, EPSS or required runtime evidence is unavailable.
+Unknown evidence is not converted to a zero score or a negative observation claim. Critical/high findings require manual review whenever age, EPSS or required runtime evidence is unavailable or coverage is insufficient.
 
 ## EPSS Policy Bands
 

--- a/policy/vulnerability-gate-policy.yml
+++ b/policy/vulnerability-gate-policy.yml
@@ -28,10 +28,16 @@ block_on:
       Any CRITICAL or HIGH CVE whose EPSS score falls into the HIGH or CRITICAL
       risk bands. EPSS is used as the exploitation-likelihood signal alongside KEV.
 
+  - condition: "critical_or_high_runtime_observed"
+    severity: [CRITICAL, HIGH]
+    description: >
+      Any CRITICAL or HIGH CVE whose package files were observed loading at runtime.
+      Confirmed execution path exposure overrides age and EPSS auto-promotion allowance.
+
   - condition: "critical_or_high_required_evidence_unknown"
     severity: [CRITICAL, HIGH]
     description: >
-      Missing publication age, EPSS data, package mapping, or runtime collection is
+      Missing publication age, EPSS data, package mapping, or runtime observation is
       treated as unknown and requires review. Unknown evidence is never converted to
       a zero score or a claim that code is unreachable.
 

--- a/site/index.html
+++ b/site/index.html
@@ -51,14 +51,14 @@
       <article>
         <h3>Registry Takeover Risk</h3>
         <p>Is the upstream registry account secure? Threat actors compromise maintainer accounts to distribute malicious updates. <br>
-        <em>Boundary:</em> <strong>Warning-Only</strong>. The gate detects signature presence, but cannot verify the original publisher account's security. We mitigate this by requiring cryptographic signing where available. <br>
-        <em>Incident:</em> The <strong>ua-parser-js library hijack (2021)</strong>, where compromised developer credentials were used to publish packages containing cryptomining malware (<a href="https://nvd.nist.gov/vuln/detail/CVE-2021-42048">CVE-2021-42048</a>).</p>
+        <em>Boundary:</em> <strong>Warning-Only</strong>. The gate warns on missing signatures, but cannot verify the original publisher account's security. <br>
+        <em>Incident:</em> The <strong>ua-parser-js library hijack (2021)</strong>, where compromised developer credentials were used to publish packages containing cryptomining malware (<a href="https://nvd.nist.gov/vuln/detail/CVE-2021-4229">CVE-2021-4229</a>).</p>
       </article>
       <article>
         <h3>Silent Tag Drift Risk</h3>
         <p>Are we pulling mutable references? Relying on tags like <code>latest</code> allows upstream code to change without your knowledge. <br>
         <em>Boundary:</em> <strong>Enforced Prevention</strong>. The ingestion gate requires resolving version tags to immutable digests first. Pinned digests cannot drift. <br>
-        <em>Incident:</em> The <strong>Docker Hub spoofing campaign (2023)</strong>, where threat actors pushed millions of drifted, malicious images spoofing legitimate software to execute cryptominers (<a href="https://sysdig.com/blog/malicious-images-docker-hub/">Sysdig Threat Report</a>).</p>
+        <em>Incident:</em> The <strong>JFrog Docker Hub poisoning campaign (2024)</strong>, where threat actors uploaded over 4 million malicious, spoofed/drifted repositories to Docker Hub to distribute phishing scams and malware (<a href="https://jfrog.com/blog/malicious-images-docker-hub/">JFrog Research</a>).</p>
       </article>
       <article>
         <h3>Socially Engineered Logic Bombs</h3>
@@ -69,13 +69,13 @@
       <article>
         <h3>Pipeline Takeover & Token Theft</h3>
         <p>Can the container compromise the build pipeline? A malicious dependency can execute install scripts to harvest secrets from ambient environment variables. <br>
-        <em>Boundary:</em> <strong>Partial Prevention</strong>. We run workflows with read-only GitHub OIDC tokens and isolate dependencies, but any build-time execution risks exfiltrating ambient variables if exposed. <br>
+        <em>Boundary:</em> <strong>Partial Prevention</strong>. We use least-privilege, job-scoped tokens — the scanning job is read-only, and write scopes are confined to the promotion jobs. <br>
         <em>Incident:</em> The <strong>Codecov Bash Uploader compromise (2021)</strong>, where a compromised script silently exfiltrated CI environment credentials (<a href="https://www.cisa.gov/news-events/alerts/2021/04/27/compromise-codecov-bash-uploader-script">CISA Alert AA21-117A</a>).</p>
       </article>
       <article>
         <h3>Container Escape & Privileges</h3>
         <p>What is the worst-case blast radius? Running as root or with high capabilities enables container breakouts to the host. <br>
-        <em>Boundary:</em> <strong>Enforced by IaC Policy</strong>. The gate scans deployment manifests for insecure capabilities or root execution and blocks them. <br>
+        <em>Boundary:</em> <strong>Enforced at Merge</strong>. The gate scans deployment manifests for insecure configurations during repository merge checks, blocking insecure configurations from entering main (not at promotion). <br>
         <em>Incident:</em> The <strong>runc container escape (2024)</strong>, where a runtime file descriptor leak allowed attackers to break container boundaries and gain host root access (<a href="https://nvd.nist.gov/vuln/detail/CVE-2024-21626">CVE-2024-21626</a>).</p>
       </article>
       <article>
@@ -88,30 +88,140 @@
         <h3>Sidecar & Runner Exposure</h3>
         <p>Are we verifying the entire bundle? Hardening the main application while leaving task runners or sidecars unverified leaves a backdoor. <br>
         <em>Boundary:</em> <strong>Enforced</strong>. The policy configures that all companion runner images must be resolved to digests and evaluated under the same promotion rules. <br>
-        <em>Incident:</em> Companion containers (such as unpinned local databases or runners) serving as entry points to otherwise secure workloads.</p>
+        <em>Rationale:</em> Companion containers (such as unpinned local databases or runners) share the host's execution environment and can serve as entry points to otherwise secure workloads.</p>
       </article>
       <article>
         <h3>Waiver & Exception Decay</h3>
         <p>Are exceptions auditable and expiring? Permanent exceptions become permanent backdoors. <br>
         <em>Boundary:</em> <strong>Enforced</strong>. The workflow requires exceptions to target specific CVEs, document compensating controls, and declare an expiry date. <br>
-        <em>Incident:</em> Stale, unmonitored security exceptions leading to compromise of legacy enterprise services.</p>
+        <em>Incident:</em> The <strong>Equifax breach (2017)</strong>, where CVE-2017-5638 in Apache Struts was known and patched upstream, but exposure persisted for months due to failed remediation and exception tracking (147 million records compromised).</p>
+      </article>
+      <article>
+        <h3>Compromised Registry Namespace</h3>
+        <p>If an attacker gains write access to our GHCR namespace, can they swap the trusted image? <br>
+        <em>Boundary:</em> <strong>Enforced by Attestation</strong>. The deployment installer does not trust registry name presence; it cryptographically verifies build attestations generated by our OIDC-backed workflow and pins the exact digests. <br>
+        <em>Rationale:</em> Attackers who compromise repository registry accounts cannot bypass admission control without also stealing the OIDC-backed signing credentials of the GitHub Actions runner.</p>
+      </article>
+      <article>
+        <h3>Third-Party Action Compromise</h3>
+        <p>Can third-party actions in GitHub workflows be updated or retagged to exfiltrate secrets or inject backdoors? <br>
+        <em>Boundary:</em> <strong>Enforced Prevention</strong>. All actions used in our promotion and CI workflows are pinned to immutable commit SHAs rather than mutable version tags. <br>
+        <em>Incident:</em> The <strong>tj-actions/changed-files compromise (March 2025)</strong>, where a compromised, retagged action leaked CI secrets across thousands of downstream repositories.</p>
+      </article>
+      <article>
+        <h3>Poisoned Pipeline Execution (PPE)</h3>
+        <p>Can a malicious pull request edit the gate's policy files (like <code>vulnerability-gate-policy.yml</code>) to weaken promotion thresholds? <br>
+        <em>Boundary:</em> <strong>Enforced by Branch Protection</strong>. Branch protection rules, required review approvals, and strict CODEOWNERS constraints prevent modifications to the <code>.github/</code> and <code>policy/</code> folders from being merged without administrator review. <br>
+        <em>Rationale:</em> Enforces segregation of duties by blocking pull requests from auto-merging policy modifications.</p>
+      </article>
+      <article>
+        <h3>Verification Bypass at Deploy</h3>
+        <p>Can developers deploy promoted images in `--insecure-lab-mode`, bypassing attestation checks entirely? <br>
+        <em>Boundary:</em> <strong>Structural Limitation</strong>. The installer allows disabling checks for local development. In production, this escape hatch must be blocked by container admission controllers (like Kyverno or Gatekeeper). <br>
+        <em>Rationale:</em> Bypassing verification in production destroys the entire chain of trust established by the promotion gate.</p>
+      </article>
+      <article>
+        <h3>Embedded Credentials in Vendor Image</h3>
+        <p>Do upstream vendors accidentally bake credentials, private keys, or API tokens into their public container layers? <br>
+        <em>Boundary:</em> <strong>Enforced Prevention</strong>. The gate runs a secret scanner (<code>trivy image --scanners secret</code>) and fails the promotion if any credentials are found. <br>
+        <em>Rationale:</em> Blocking hardcoded secrets at the gate prevents leaked vendor credentials from being deployed to production environments.</p>
       </article>
     </div>
-  </section>
-
   <section>
-    <p class="kicker">WHERE TRUST AND RULES ARE DEFINED</p>
-    <h2>Policy is visible, version-controlled and reviewable</h2>
+    <p class="kicker">CONTROL INVENTORY</p>
+    <h2>Active Pipeline Control Mapping</h2>
     <div class="table-scroll"><table class="rule-table">
-      <thead><tr><th scope="col">Control</th><th scope="col">Current rule</th><th scope="col">Source of truth</th></tr></thead>
+      <thead>
+        <tr>
+          <th scope="col">Control</th>
+          <th scope="col">Risk Addressed</th>
+          <th scope="col">Function</th>
+          <th scope="col">Control Point</th>
+          <th scope="col">Enforcement</th>
+          <th scope="col">Source of Truth</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><th scope="row">Trusted intake</th><td>Only <code>n8nio/n8n</code> and <code>n8nio/runners</code>; strict <code>x.y.z</code> versions. <code>latest</code> must resolve before use.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/image-ingestion-policy.yml">image-ingestion-policy.yml</a></td></tr>
-        <tr><th scope="row">Vendor identity gap</th><td>Upstream signature verification is currently warning-only, with accepted risk and review date recorded in policy.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/image-ingestion-policy.yml">vendor_signature</a></td></tr>
-        <tr><th scope="row">Automatic gate</th><td>Critical/high findings require review for a KEV match, age ≥30 days, EPSS ≥2%, or unknown required evidence.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/vulnerability-gate-policy.yml">vulnerability-gate-policy.yml</a></td></tr>
-        <tr><th scope="row">Manual exception</th><td>Requires detailed justification and compensating controls, generating cryptographically signed <code>OpenVEX</code> exception files.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/image-promotion.yml">image-promotion.yml</a></td></tr>
-        <tr><th scope="row">Trusted outputs</th><td>Accepted images go to <code>artifactgate/n8n-trusted</code> and <code>artifactgate/n8n-runners-trusted</code>, with separate attestations.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/docs/signing-and-attestation.md">signing and attestation</a></td></tr>
-        <tr><th scope="row">Deployment admission</th><td>Both attestations must verify against owner <code>llody9977</code>; both images are deployed by digest.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/iac/n8n/install.sh">install.sh</a></td></tr>
-        <tr><th scope="row">Ongoing review</th><td>The latest promoted release is re-scanned weekly; policy regressions open a security issue.</td><td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/rescan.yml">rescan.yml</a></td></tr>
+        <tr>
+          <th scope="row">Source Ingestion Allowlist</th>
+          <td>Rogue tag intake & untrusted vendors</td>
+          <td>Preventive</td>
+          <td>Intake</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/image-ingestion-policy.yml">image-ingestion-policy.yml</a></td>
+        </tr>
+        <tr>
+          <th scope="row">OCI Digest Resolution</th>
+          <td>Tag drift & tag poisoning</td>
+          <td>Preventive</td>
+          <td>Intake</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/image-promotion.yml">image-promotion.yml</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Trivy Malware & Secret Scan</th>
+          <td>Embedded secrets, keys, and malware</td>
+          <td>Preventive</td>
+          <td>Promotion Gate</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/image-promotion.yml">image-promotion.yml</a></td>
+        </tr>
+        <tr>
+          <th scope="row">OWASP ZAP DAST Scan</th>
+          <td>Runtime network / HTTP vulnerabilities</td>
+          <td>Preventive</td>
+          <td>Promotion Gate</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/scripts/run_tracee_reachability.sh">run_tracee_reachability.sh</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Trivy Licence Scan</th>
+          <td>Copyleft licence liabilities</td>
+          <td>Detective</td>
+          <td>Promotion Gate</td>
+          <td>Advisory</td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/image-promotion.yml">image-promotion.yml</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Runtime eBPF Observation</th>
+          <td>Logic bombs & active execution paths</td>
+          <td>Detective</td>
+          <td>Promotion Gate</td>
+          <td><strong>Blocking</strong> (Escalated on Observed)</td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/scripts/merge_tracee_reachability.py">merge_tracee_reachability.py</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Vulnerability Risk Enrichment</th>
+          <td>Vulnerability exploitation (KEV/EPSS/Age)</td>
+          <td>Preventive</td>
+          <td>Promotion Gate</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/policy/vulnerability-gate-policy.yml">vulnerability-gate-policy.yml</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Actions SHA Pinning & Tokens</th>
+          <td>Pipeline takeover & third-party compromises</td>
+          <td>Preventive</td>
+          <td>Build / Pipeline</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/ci.yml">Workflow Configurations</a></td>
+        </tr>
+        <tr>
+          <th scope="row">OIDC Provenance & SBOM</th>
+          <td>Registry bypass & image swapping</td>
+          <td>Preventive</td>
+          <td>Attestation / Deploy</td>
+          <td><strong>Blocking</strong></td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/iac/n8n/install.sh">install.sh</a></td>
+        </tr>
+        <tr>
+          <th scope="row">Continuous Re-Scanning</th>
+          <td>Post-promotion security decay</td>
+          <td>Corrective</td>
+          <td>Continuous</td>
+          <td><strong>Blocking</strong> (Opens Issues)</td>
+          <td><a href="https://github.com/llody9977/artifactgate/blob/main/.github/workflows/rescan.yml">rescan.yml</a></td>
+        </tr>
       </tbody>
     </table></div>
     <p class="note">Policy changes go through the same protected pull-request path as code. The readable YAML documents intent; the workflow and enrichment script enforce the executable decision.</p>
@@ -123,9 +233,10 @@
     <div class="standards">
       <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/161/r1/upd1/final">NIST SP 800-161 Rev. 1</a></h3><p>Third-party technology is a supply-chain risk requiring due diligence, assessment, mitigation and continuing oversight.</p></article>
       <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/190/final">NIST SP 800-190</a></h3><p>Informs trusted-image handling, registry controls, vulnerability management and hardened container configuration.</p></article>
-      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/218/final">NIST SP 800-218</a></h3><p>Informs third-party component verification and the collection and protection of release integrity and provenance data.</p></article>
+      <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/218/final">NIST SP 800-218</a></h3><p>Informs third-party component verification (practices PO.1.3, PO.3.2, PW.4.1, PW.4.4, RV.1.1, RV.1.3).</p></article>
       <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/204/d/final">NIST SP 800-204D</a></h3><p>Frames how provenance, attestations, SBOMs and supply-chain controls fit into CI/CD.</p></article>
-      <article><h3><a href="https://slsa.dev/spec/v1.2/">SLSA v1.2</a></h3><p>Provides a model for provenance and verification. ArtifactGate claims no SLSA level for an upstream image it did not build.</p></article>
+      <article><h3><a href="https://slsa.dev/spec/v1.2/">SLSA v1.2</a></h3><p>Provides a model for provenance. ArtifactGate's promotion steps exhibit SLSA Build L2/L3 properties.</p></article>
+      <article><h3>EU CRA & NTIA Elements</h3><p>Aligns with NTIA Minimum Elements for an SBOM and EU Cyber Resilience Act VEX vulnerability reporting rules.</p></article>
     </div>
   </section>
 


### PR DESCRIPTION
This PR refines the repository's security posture by enforcing ZAP DAST scans as blockers, renaming 'reachability' to 'runtime observation' to avoid overclaims, calculating package coverage with a 20% downgrade fail-closed rule, adding 5 new risks, mapping SSDF and SP 800-53 controls, and integrating a full Control Inventory table on the site and docs.