### PR TITLE
style: link EU CRA/NTIA standards and fix SVG re-scan loop overlap

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -153,7 +153,7 @@
     <p>The upstream image is never treated as internally trusted merely because it can be pulled. ArtifactGate resolves the digest first, evaluates the application and runner together, fails closed when required evidence is unknown, and promotes the accepted pair into a controlled namespace. Deployment verifies GitHub OIDC-backed attestations and pins both digests.</p>
 
     <!-- Visual Architecture & Workflow Diagram -->
-    <svg class="flow-svg" viewBox="0 0 920 370" width="100%" height="auto" style="margin-top: 2rem; padding: 1.5rem;">
+    <svg class="flow-svg" viewBox="0 0 920 380" width="100%" height="auto" style="margin-top: 2rem; padding: 1.5rem;">
       <!-- Definitions for gradients and markers -->
       <defs>
         <marker id="arrow" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -237,8 +237,8 @@
       <path d="M 695 315 L 720 315 L 720 120" stroke="#b06000" stroke-width="1.5" fill="none" />
 
       <!-- Weekly Re-Scan Loop -->
-      <path d="M 740 315 L 205 315 L 205 130" stroke="#1a73e8" stroke-dasharray="4 4" stroke-width="1.5" fill="none" marker-end="url(#arrow)" />
-      <text x="215" y="295" font-size="10" font-family="system-ui, sans-serif" fill="#1a73e8" font-weight="bold">Weekly Re-Scan Loop</text>
+      <path d="M 820 350 L 820 365 L 205 365 L 205 130" stroke="#1a73e8" stroke-dasharray="4 4" stroke-width="1.5" fill="none" marker-end="url(#arrow)" />
+      <text x="215" y="358" font-size="10" font-family="system-ui, sans-serif" fill="#1a73e8" font-weight="bold">Weekly Re-Scan Loop</text>
     </svg>
 
     <!-- Interactive Step-by-Step Flowchart Cards -->
@@ -428,7 +428,7 @@
       <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/218/final">NIST SP 800-218</a></h3><p>Informs third-party component verification (practices PO.1.3, PO.3.2, PW.4.1, PW.4.4, RV.1.1, RV.1.3).</p></article>
       <article><h3><a href="https://csrc.nist.gov/pubs/sp/800/204/d/final">NIST SP 800-204D</a></h3><p>Frames how provenance, attestations, SBOMs and supply-chain controls fit into CI/CD.</p></article>
       <article><h3><a href="https://slsa.dev/spec/v1.2/">SLSA v1.2</a></h3><p>Provides a model for provenance. ArtifactGate's promotion steps exhibit SLSA Build L2/L3 properties.</p></article>
-      <article><h3>EU CRA & NTIA Elements</h3><p>Aligns with NTIA Minimum Elements for an SBOM and EU Cyber Resilience Act VEX vulnerability reporting rules.</p></article>
+      <article><h3><a href="https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act">EU CRA</a> &amp; <a href="https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf">NTIA Elements</a></h3><p>Aligns with NTIA Minimum Elements for an SBOM and EU Cyber Resilience Act VEX vulnerability reporting rules.</p></article>
     </div>
   </section>
 


### PR DESCRIPTION
Embeds hyperlinks for EU CRA and NTIA Elements standard in the frontend page, adjusts the SVG viewBox height, and reroutes the Weekly Re-Scan Loop path below the manual review box to prevent visual overlap.