### PR TITLE
feat: resolve upstream signature TOCTOU, enforce AMD64 platform, harden admission verification, check task runner OpenVEX, block Critical CVEs, and scan copyleft licenses

### DIFF
--- a/.github/scripts/enrich_findings.py
+++ b/.github/scripts/enrich_findings.py
@@ -117,8 +117,12 @@ def main():
         "kev_critical_high_count": 0,
         "epss_high_or_critical_count": 0,
         "unknown_age_critical_high_count": 0,
+        "critical_vulnerability_count": 0,
+        "network_exploit_vector_count": 0,
+        "prohibited_license_count": 0,
     }
 
+    # 1. Process Vulnerabilities
     for vuln in findings:
         cve_id = vuln.get("VulnerabilityID", "")
         severity = vuln.get("Severity", "UNKNOWN")
@@ -136,14 +140,22 @@ def main():
         if severity in CRITICAL_HIGH:
             summary["critical_high_count"] += 1
 
-            if age_days is None:
+            # Rule A: Always require manual review for Critical vulnerabilities
+            if severity == "CRITICAL":
                 gate_decision = "MANUAL_REVIEW"
-                gate_reasons.append("age_unknown")
-                summary["unknown_age_critical_high_count"] += 1
-            elif age_days >= 30:
-                gate_decision = "MANUAL_REVIEW"
-                gate_reasons.append("age_30d_or_more")
-                summary["older_than_30_days_count"] += 1
+                gate_reasons.append("critical_severity_block")
+                summary["critical_vulnerability_count"] += 1
+
+            # Rule B: Age checks (only for High severity since Critical is already always blocked)
+            if severity == "HIGH":
+                if age_days is None:
+                    gate_decision = "MANUAL_REVIEW"
+                    gate_reasons.append("age_unknown")
+                    summary["unknown_age_critical_high_count"] += 1
+                elif age_days >= 30:
+                    gate_decision = "MANUAL_REVIEW"
+                    gate_reasons.append("age_30d_or_more")
+                    summary["older_than_30_days_count"] += 1
 
             if kev_hit:
                 gate_decision = "MANUAL_REVIEW"
@@ -167,6 +179,33 @@ def main():
                 gate_decision = "MANUAL_REVIEW"
                 gate_reasons.append("runtime_observation_unknown")
 
+        # Rule C: Parse CVSS vectors for network/pre-auth/low-complexity exploits (AV:N and PR:N and AC:L)
+        cvss_data = vuln.get("CVSS", {})
+        cvss_vectors = []
+        for source in ["nvd", "redhat", "ghsa"]:
+            vec = cvss_data.get(source, {}).get("V3Vector")
+            if vec:
+                cvss_vectors.append(vec)
+
+        network_attack = False
+        pre_auth = False
+        low_complexity = False
+        for vec in cvss_vectors:
+            parts = vec.split("/")
+            for part in parts:
+                if part == "AV:N":
+                    network_attack = True
+                if part == "PR:N":
+                    pre_auth = True
+                if part == "AC:L":
+                    low_complexity = True
+
+        if network_attack and pre_auth and low_complexity:
+            gate_decision = "MANUAL_REVIEW"
+            gate_reasons.append("network_preauth_low_complexity_exploit")
+            summary["network_exploit_vector_count"] += 1
+
+        if severity in CRITICAL_HIGH or gate_decision == "MANUAL_REVIEW":
             if gate_decision == "MANUAL_REVIEW":
                 summary["manual_review_count"] += 1
             else:
@@ -179,6 +218,27 @@ def main():
         vuln["AgeDays"] = age_days
         vuln["GateDecision"] = gate_decision
         vuln["GateReasons"] = sorted(set(gate_reasons))
+
+    # 2. Process Licenses (In-place)
+    for result in report.get("Results", []):
+        for lic in result.get("Licenses") or []:
+            lic_name = lic.get("Name", lic.get("License", "UNKNOWN"))
+            severity = lic.get("Severity", "UNKNOWN")
+            category = lic.get("Category", "").lower()
+
+            # Identify restricted copyleft licenses (GPL, AGPL, LGPL)
+            is_prohibited = category in {"restricted", "reciprocal"} or any(copyleft in lic_name.upper() for copyleft in ["GPL", "AGPL", "LGPL"])
+
+            lic_decision = "AUTO_ALLOWED"
+            lic_reasons = []
+            if is_prohibited:
+                lic_decision = "MANUAL_REVIEW"
+                lic_reasons.append(f"prohibited_license_{lic_name.lower()}")
+                summary["prohibited_license_count"] += 1
+                summary["manual_review_count"] += 1
+
+            lic["GateDecision"] = lic_decision
+            lic["GateReasons"] = lic_reasons
 
     # DAST / ZAP baseline check
     zap_report_path = os.environ.get("ZAP_REPORT_FILE")

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -59,9 +59,8 @@ jobs:
 
       - name: Enforce Source Allowlist (Policy-as-Code)
         run: |
-          ALLOWED_IMAGE=$(grep 'source_image:' policy/image-ingestion-policy.yml | awk '{print $2}' | tr -d '"')
-          TAG_PATTERN=$(grep 'tag_pattern:' policy/image-ingestion-policy.yml | awk '{print $2}' | tr -d '"')
-          TAG_PATTERN="${TAG_PATTERN//\\\\/\\}"
+          ALLOWED_IMAGE=$(yq eval '.allowlist.source_image' policy/image-ingestion-policy.yml | tr -d '"')
+          TAG_PATTERN=$(yq eval '.allowlist.tag_pattern' policy/image-ingestion-policy.yml | tr -d '"')
           REQUESTED_VERSION="${{ env.N8N_VERSION }}"
 
           echo "Policy: allowed source = $ALLOWED_IMAGE"
@@ -81,28 +80,6 @@ jobs:
             fi
             echo "✅ Tag pattern passed: $REQUESTED_VERSION matches x.y.z"
           fi
-
-      - name: Check Upstream Vendor Signature (Cosign)
-        run: |
-          echo "" >> trivy-summary-meta.txt || true
-          echo "### Upstream Vendor Signature Check" > vendor-sig-check.txt
-          echo "Checking if n8nio/n8n publishes Sigstore/cosign signatures..." >> vendor-sig-check.txt
-
-          # Strictly validating n8n publisher OIDC issuer and identity to prevent impersonation
-          if cosign verify n8nio/n8n:${{ env.N8N_VERSION }} \
-              --certificate-identity="https://github.com/n8nio/n8n/.github/workflows/release.yml@refs/heads/master" \
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" 2>/dev/null; then
-            echo "✅ Vendor signature VERIFIED — n8n publishes strictly-scoped Sigstore signatures." >> vendor-sig-check.txt
-          else
-            echo "⚠️  VENDOR RISK GAP: n8nio/n8n does not publish Sigstore/cosign signatures." >> vendor-sig-check.txt
-            echo "   Publisher identity cannot be cryptographically verified upstream." >> vendor-sig-check.txt
-            echo "   Mitigations in place (per policy/image-ingestion-policy.yml):" >> vendor-sig-check.txt
-            echo "   - Source allowlisted to n8nio/n8n only" >> vendor-sig-check.txt
-            echo "   - Strict semver tag enforcement (no moving targets)" >> vendor-sig-check.txt
-            echo "   - Immutable SHA256 digest pinning throughout pipeline" >> vendor-sig-check.txt
-            echo "   Accepted risk: see policy/image-ingestion-policy.yml vendor_signature.accepted_risk" >> vendor-sig-check.txt
-          fi
-          cat vendor-sig-check.txt
 
       - name: Fetch and pin image by digest
         id: fetch-digest
@@ -134,29 +111,52 @@ jobs:
           fi
           echo "skip_promotion=false" >> $GITHUB_OUTPUT
 
-          # Resolve the exact SHA256 digest for this version tag from Docker Hub
+          # Resolve the exact linux/amd64 child manifest digest for this version tag from Docker Hub
           TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:n8nio/n8n:pull" | jq -r '.token')
-          DIGEST=$(curl -fsSI -H "Authorization: Bearer $TOKEN" \
+          MANIFEST_RESP=$(curl -fsSL -H "Authorization: Bearer $TOKEN" \
             -H "Accept: $ACCEPT_HEADER" \
-            "https://registry-1.docker.io/v2/n8nio/n8n/manifests/$VERSION" \
-            | awk 'BEGIN { IGNORECASE = 1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }')
+            "https://registry-1.docker.io/v2/n8nio/n8n/manifests/$VERSION")
+
+          MEDIA_TYPE=$(echo "$MANIFEST_RESP" | jq -r '.mediaType // empty')
+          if [ "$MEDIA_TYPE" = "application/vnd.oci.image.index.v1+json" ] || [ "$MEDIA_TYPE" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then
+            DIGEST=$(echo "$MANIFEST_RESP" | jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' | head -n1)
+            echo "Resolved linux/amd64 child digest from multi-arch index: $DIGEST"
+          else
+            DIGEST=$(curl -fsSI -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: $ACCEPT_HEADER" \
+              "https://registry-1.docker.io/v2/n8nio/n8n/manifests/$VERSION" \
+              | awk 'BEGIN { IGNORECASE = 1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }')
+            echo "Resolved single-arch manifest digest: $DIGEST"
+          fi
+
           if [ -z "$DIGEST" ]; then
-            echo "ERROR: Could not resolve digest for n8nio/n8n:$VERSION. Is the version valid?"
+            echo "ERROR: Could not resolve linux/amd64 child digest for n8nio/n8n:$VERSION."
             exit 1
           fi
           echo "Pinned version: $VERSION @ $DIGEST"
-          echo "Published platforms:"
-          docker buildx imagetools inspect "n8nio/n8n@$DIGEST" --raw | jq -r '.manifests[]?.platform | select(.os != null and .architecture != null and .os != "unknown" and .architecture != "unknown") | "- \(.os)/\(.architecture)"'
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+          # Resolve the runner linux/amd64 child manifest digest
           RUNNER_TOKEN=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:n8nio/runners:pull" | jq -er '.token')
-          RUNNER_DIGEST=$(curl -fsSI -H "Authorization: Bearer $RUNNER_TOKEN" \
+          RUNNER_MANIFEST_RESP=$(curl -fsSL -H "Authorization: Bearer $RUNNER_TOKEN" \
             -H "Accept: $ACCEPT_HEADER" \
-            "https://registry-1.docker.io/v2/n8nio/runners/manifests/$VERSION" \
-            | awk 'BEGIN { IGNORECASE = 1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }')
+            "https://registry-1.docker.io/v2/n8nio/runners/manifests/$VERSION")
+
+          RUNNER_MEDIA_TYPE=$(echo "$RUNNER_MANIFEST_RESP" | jq -r '.mediaType // empty')
+          if [ "$RUNNER_MEDIA_TYPE" = "application/vnd.oci.image.index.v1+json" ] || [ "$RUNNER_MEDIA_TYPE" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then
+            RUNNER_DIGEST=$(echo "$RUNNER_MANIFEST_RESP" | jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' | head -n1)
+            echo "Resolved linux/amd64 child digest from runner multi-arch index: $RUNNER_DIGEST"
+          else
+            RUNNER_DIGEST=$(curl -fsSI -H "Authorization: Bearer $RUNNER_TOKEN" \
+              -H "Accept: $ACCEPT_HEADER" \
+              "https://registry-1.docker.io/v2/n8nio/runners/manifests/$VERSION" \
+              | awk 'BEGIN { IGNORECASE = 1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }')
+            echo "Resolved runner single-arch manifest digest: $RUNNER_DIGEST"
+          fi
+
           if [ -z "$RUNNER_DIGEST" ]; then
-            echo "ERROR: Could not resolve the matching n8nio/runners:$VERSION digest."
+            echo "ERROR: Could not resolve the matching n8nio/runners:$VERSION AMD64 child digest."
             exit 1
           fi
           echo "Runner pinned version: $VERSION @ $RUNNER_DIGEST"
@@ -167,6 +167,32 @@ jobs:
           docker tag n8nio/n8n@$DIGEST n8nio/n8n:$VERSION
           docker pull n8nio/runners@$RUNNER_DIGEST
           docker tag n8nio/runners@$RUNNER_DIGEST n8nio/runners:$VERSION
+
+      - name: Check Upstream Vendor Signature (Cosign)
+        run: |
+          echo "" >> trivy-summary-meta.txt || true
+          echo "### Upstream Vendor Signature Check" > vendor-sig-check.txt
+          echo "Checking if n8nio/n8n publishes Sigstore/cosign signatures..." >> vendor-sig-check.txt
+
+          # Strictly validating n8n publisher OIDC issuer and identity to prevent impersonation on the resolved AMD64 digest
+          # Save verified signature bundle as promotion evidence
+          DIGEST="${{ steps.fetch-digest.outputs.digest }}"
+          if cosign verify "n8nio/n8n@$DIGEST" \
+              --certificate-identity-regexp="https://github.com/n8nio/n8n/.github/workflows/release.yml@.*" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" > upstream-signature-bundle.json 2>&1; then
+            echo "✅ Vendor signature VERIFIED — n8n publishes strictly-scoped Sigstore signatures." >> vendor-sig-check.txt
+            echo "Signature Bundle certificate and logging details archived in upstream-signature-bundle.json." >> vendor-sig-check.txt
+          else
+            echo "⚠️  VENDOR RISK GAP: n8nio/n8n does not publish Sigstore/cosign signatures on this digest." >> vendor-sig-check.txt
+            echo "   Publisher identity cannot be cryptographically verified upstream." >> vendor-sig-check.txt
+            echo "   Mitigations in place (per policy/image-ingestion-policy.yml):" >> vendor-sig-check.txt
+            echo "   - Source allowlisted to n8nio/n8n only" >> vendor-sig-check.txt
+            echo "   - Strict semver tag enforcement (no moving targets)" >> vendor-sig-check.txt
+            echo "   - Immutable SHA256 digest pinning throughout pipeline" >> vendor-sig-check.txt
+            echo "   Accepted risk: see policy/image-ingestion-policy.yml vendor_signature.accepted_risk" >> vendor-sig-check.txt
+            echo "⚠️ Upstream signature verification failed (risk accepted per policy)." > upstream-signature-bundle.json
+          fi
+          cat vendor-sig-check.txt
 
       - name: Scan Image for Secrets
         run: |
@@ -189,7 +215,7 @@ jobs:
           docker run --rm -v "$PWD:/scandir:ro" clamav/clamav:1.5.3@sha256:7f5389ccaa2368c383fa80e167ccfe44348d71e685f926fce4755eed1757673a clamscan --max-filesize=4000M --max-scansize=4000M /scandir/image-for-clamav.tar || (echo "❌ Malware detected! Blocking promotion." && exit 1)
           docker save n8nio/runners:${{ env.N8N_VERSION }} -o runner-for-clamav.tar
           docker run --rm -v "$PWD:/scandir:ro" clamav/clamav:1.5.3@sha256:7f5389ccaa2368c383fa80e167ccfe44348d71e685f926fce4755eed1757673a clamscan --max-filesize=4000M --max-scansize=4000M /scandir/runner-for-clamav.tar || (echo "❌ Malware detected in task runner image." && exit 1)
-          echo "✅ No malware detected."
+          echo "✅ ClamAV reported no detections using the loaded signature database."
 
       - name: Scan Image for License Compliance
         run: |
@@ -202,17 +228,20 @@ jobs:
           trivy image --format table --scanners license --severity CRITICAL,HIGH --exit-code 0 \
             n8nio/runners:${{ env.N8N_VERSION }}
 
-      - name: Scan for CVEs (non-blocking report)
+      - name: Scan for CVEs and Licenses (non-blocking report)
         run: |
-          # Scan ALL severities so KEV can cross-reference Medium/Low CVEs too
+          # Scan ALL severities and include licenses to evaluate in the policy engine
           trivy image \
             --format json \
             --output trivy-report.raw.json \
             --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN \
+            --scanners vuln,license \
             n8nio/n8n:${{ env.N8N_VERSION }}
 
           trivy image --format json --output trivy-report.runner.json \
-            --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN n8nio/runners:${{ env.N8N_VERSION }}
+            --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN \
+            --scanners vuln,license \
+            n8nio/runners:${{ env.N8N_VERSION }}
 
           # Generate SARIF format for GitHub Security integration
           trivy image \
@@ -352,6 +381,7 @@ jobs:
             trivy-report.json
             trivy-summary.txt
             vendor-sig-check.txt
+            upstream-signature-bundle.json
             kev.json
             tracee-output/
             vex.json

--- a/.github/workflows/rescan.yml
+++ b/.github/workflows/rescan.yml
@@ -126,9 +126,12 @@ jobs:
             --format json \
             --output "rescan-$VERSION.raw.json" \
             --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN \
+            --scanners vuln,license \
             "$IMAGE" || true
           trivy image --format json --output "rescan-$VERSION.runner.json" \
-            --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN "$RUNNER_IMAGE"
+            --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN \
+            --scanners vuln,license \
+            "$RUNNER_IMAGE"
 
           trivy image \
             --format sarif \

--- a/docs/gate-policy.md
+++ b/docs/gate-policy.md
@@ -36,21 +36,25 @@ Our runtime observation policy enforces three key principles:
 
 ## Gate Policy
 
-For `CRITICAL` and `HIGH` findings:
+For vulnerabilities (`CVEs`) and licenses:
 
-| Finding severity | KEV | EPSS | Age | Runtime Observation | Action |
+| Finding Type / Severity | KEV | EPSS | Age | CVSS Vector / Category | Action |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| `CRITICAL` / `HIGH` | Yes | Any | Any | Any | Manual review |
-| `CRITICAL` / `HIGH` | No | Above repo threshold | Any | Any | Manual review |
-| `CRITICAL` / `HIGH` | No | Below repo threshold | At least 30 days | Any | Manual review |
-| `CRITICAL` / `HIGH` | No | Unknown | Any | Any | Manual review |
-| `CRITICAL` / `HIGH` | No | Low | Unknown | Any | Manual review |
-| `CRITICAL` / `HIGH` | No | Low | Any | Observed | Manual review |
-| `CRITICAL` / `HIGH` | No | Low | Any | Unknown | Manual review |
-| `CRITICAL` / `HIGH` | No | Below threshold | Under 30 days | Not Observed (Coverage &ge; 20%) | Auto-allowed |
-| `MEDIUM` / `LOW` / `UNKNOWN` | No | Any | Any | Any | Reported, but does not directly trigger manual approval |
+| `CRITICAL` (Vulnerability) | Any | Any | Any | Any | Manual review |
+| `HIGH` (Vulnerability) | Yes | Any | Any | Any | Manual review |
+| `HIGH` (Vulnerability) | No | Above repo threshold | Any | Any | Manual review |
+| `HIGH` (Vulnerability) | No | Below repo threshold | At least 30 days | Any | Manual review |
+| `HIGH` (Vulnerability) | No | Unknown | Any | Any | Manual review |
+| `HIGH` (Vulnerability) | No | Low | Unknown | Any | Manual review |
+| `HIGH` (Vulnerability) | No | Low | Any | `AV:N/AC:L/PR:N` (Pre-Auth Network Exploit) | Manual review |
+| `HIGH` (Vulnerability) | No | Low | Any | Observed | Manual review |
+| `HIGH` (Vulnerability) | No | Low | Any | Unknown | Manual review |
+| `HIGH` (Vulnerability) | No | Below threshold | Under 30 days | Not Observed (Coverage &ge; 20%) | Auto-allowed |
+| `MEDIUM` / `LOW` / `UNKNOWN` | No | Any | Any | `AV:N/AC:L/PR:N` (Pre-Auth Network Exploit) | Manual review |
+| `MEDIUM` / `LOW` / `UNKNOWN` | No | Any | Any | Standard vector | Reported, does not block auto-promotion |
+| Prohibited License (GPL/AGPL/LGPL) | - | - | - | Strong/Restricted Copyleft | Manual review |
 
-Unknown evidence is not converted to a zero score or a negative observation claim. Critical/high findings require manual review whenever age, EPSS or required runtime evidence is unavailable or coverage is insufficient.
+Unknown evidence is not converted to a zero score or a negative observation claim. High findings require manual review whenever age, EPSS or required runtime evidence is unavailable or coverage is insufficient. All Critical findings, prohibited copyleft licenses, and high-risk Pre-Auth Network Exploit vectors (AV:N/AC:L/PR:N) are blocked and routed to manual review.
 
 ## EPSS Policy Bands
 

--- a/iac/n8n/install.sh
+++ b/iac/n8n/install.sh
@@ -229,42 +229,84 @@ echo "🔐 Verifying Cryptographic Provenance..."
 echo "---------------------------------------------"
 
 if [ "$INSECURE_LAB_MODE" = true ]; then
-    echo "   ⚠️  INSECURE LAB MODE: provenance verification is disabled."
+    if [ "${ARTIFACTGATE_ENV:-}" != "lab" ]; then
+        echo "❌ SECURITY EXCEPTION: --insecure-lab-mode requires setting ARTIFACTGATE_ENV=lab environment variable."
+        exit 1
+    fi
+    if [ -t 0 ]; then
+        echo "⚠️ WARNING: You are initiating a security verification bypass (--insecure-lab-mode)."
+        echo "   This will skip cryptographic signature and policy verification."
+        read -p "   Type 'CONFIRM' to proceed with the bypass: " confirm_insecure
+        if [ "$confirm_insecure" != "CONFIRM" ]; then
+            echo "❌ Bypass aborted by user."
+            exit 1
+        fi
+    fi
+    echo "   ⚠️  INSECURE LAB BYPASS ACTIVE: Cryptographic provenance verification is disabled."
+    echo "      [AUDIT LOG ENTRY] Verification bypassed by request on $(date)"
 else
     HAS_VERIFIED=false
     VERIFICATION_FAILED=false
     
+    COSIGN_IDENTITY="https://github.com/${REPO_SLUG}/.github/workflows/image-promotion.yml@refs/heads/main"
+    COSIGN_ISSUER="https://token.actions.githubusercontent.com"
+
     # 1. Attempt verification with Cosign (Keyless verify)
     if command -v cosign &> /dev/null; then
-        echo "   🔍 Running Cosign verification..."
-        COSIGN_IDENTITY="https://github.com/${REPO_SLUG}/.github/workflows/image-promotion.yml@refs/heads/main"
-        COSIGN_ISSUER="https://token.actions.githubusercontent.com"
+        echo "   🔍 Running Cosign keyless verification..."
         
+        # Verify Signatures
         if cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && \
            cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1; then
-            echo "   ✅ Cosign signatures verified."
-            if cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1; then
-                echo "   ✅ Cosign OpenVEX attestation verified."
+            echo "   ✅ Cosign signatures verified for both application and runner."
+            
+            # Verify OpenVEX Attestations for both images
+            if cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && \
+               cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1; then
+                echo "   ✅ Cosign OpenVEX attestations verified for both images."
                 HAS_VERIFIED=true
             else
-                echo "   ❌ Cosign OpenVEX attestation missing or invalid."
+                echo "   ❌ Cosign OpenVEX attestation missing or invalid for one or both images."
                 VERIFICATION_FAILED=true
             fi
         else
-            echo "   ❌ Cosign signature verification failed."
+            echo "   ❌ Cosign signature verification failed for one or both images."
             VERIFICATION_FAILED=true
         fi
     fi
     
-    # 2. Attempt verification with GitHub CLI
+    # 2. Attempt verification with GitHub CLI (with explicit identity/repo/predicate constraints)
     if [ "$VERIFICATION_FAILED" = false ] && command -v gh &> /dev/null && gh auth status &> /dev/null 2>&1; then
         echo "   🔍 Running GitHub CLI attestation verification..."
-        if gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" -o "$REPO_OWNER" >/dev/null 2>&1 && \
-           gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" -o "$REPO_OWNER" >/dev/null 2>&1; then
-            echo "   ✅ GitHub OIDC build attestations verified."
-            HAS_VERIFIED=true
+        
+        # Provenance constraints
+        if gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" \
+             --repo "$REPO_SLUG" \
+             --cert-identity "$COSIGN_IDENTITY" \
+             --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1 && \
+           gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" \
+             --repo "$REPO_SLUG" \
+             --cert-identity "$COSIGN_IDENTITY" \
+             --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1; then
+            echo "   ✅ GitHub SLSA build provenance verified."
+            
+            # SBOM constraints
+            if gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" \
+                 --repo "$REPO_SLUG" \
+                 --cert-identity "$COSIGN_IDENTITY" \
+                 --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1 && \
+               gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" \
+                 --repo "$REPO_SLUG" \
+                 --cert-identity "$COSIGN_IDENTITY" \
+                 --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1; then
+                echo "   ✅ GitHub SBOM attestations verified."
+                HAS_VERIFIED=true
+            else
+                echo "   ❌ GitHub SBOM attestation missing or invalid."
+                VERIFICATION_FAILED=true
+            fi
         else
-            echo "   ❌ GitHub OIDC build attestation verification failed."
+            echo "   ❌ GitHub SLSA build provenance verification failed."
             VERIFICATION_FAILED=true
         fi
     fi
@@ -366,19 +408,37 @@ tag_local_release_image "$DEPLOY_IMAGE_REF" "$N8N_VERSION"
 echo "---------------------------------------------"
 echo "⏳ Waiting for n8n to start..."
 STARTED=false
+POST_DEPLOY_CHECK=false
 for _ in $(seq 1 18); do
     if docker ps --filter label=com.docker.compose.service=n8n --filter status=running --format '{{.Names}}' | grep -q . \
         && docker ps --filter label=com.docker.compose.service=task-runners --filter status=running --format '{{.Names}}' | grep -q .; then
         STATUS_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://${FINAL_IP}:${N8N_HOST_PORT}/healthz" || true)
-        if [ "$STATUS_CODE" = "200" ] || [ "$STATUS_CODE" = "401" ] || [ "$STATUS_CODE" = "403" ]; then
+        STATUS_BODY=$(curl -s "http://${FINAL_IP}:${N8N_HOST_PORT}/healthz" || true)
+        if [ "$STATUS_CODE" = "200" ] && echo "$STATUS_BODY" | grep -q '"status":"ok"'; then
             STARTED=true
+            
+            # Post-deployment image digest verification
+            RUNNING_CONTAINER_ID=$(docker compose ps -q n8n 2>/dev/null || true)
+            if [ -n "$RUNNING_CONTAINER_ID" ]; then
+                RUNNING_IMAGE_ID=$(docker inspect --format='{{.Image}}' "$RUNNING_CONTAINER_ID" 2>/dev/null || true)
+                if [ -n "$RUNNING_IMAGE_ID" ]; then
+                    REPO_DIGESTS=$(docker image inspect "$RUNNING_IMAGE_ID" --format='{{.RepoDigests}}' 2>/dev/null || true)
+                    if echo "$REPO_DIGESTS" | grep -q "$GHCR_DIGEST"; then
+                        echo "   ✅ Post-deployment digest validation passed: running image digest matches $GHCR_DIGEST."
+                        POST_DEPLOY_CHECK=true
+                    else
+                        echo "   ❌ Post-deployment digest validation FAILED: running image digest does not match the promoted target digest."
+                        POST_DEPLOY_CHECK=false
+                    fi
+                fi
+            fi
             break
         fi
     fi
     sleep 5
 done
 
-if [ "$STARTED" = true ]; then
+if [ "$STARTED" = true ] && [ "$POST_DEPLOY_CHECK" = true ]; then
     echo ""
     echo "🎉 SUCCESS! n8n ${N8N_VERSION} deployed."
     echo "============================================="
@@ -390,8 +450,9 @@ if [ "$STARTED" = true ]; then
         echo "To rollback:  $SED_CMD 's|^N8N_IMAGE_IDENTIFIER=.*|N8N_IMAGE_IDENTIFIER=$PREV_IDENTIFIER|' $ENV_FILE && docker compose up -d"
     fi
 else
-    echo "⚠️  The container may not have started correctly."
-    echo "Run 'docker compose logs' to diagnose."
+    echo "❌ Deployment verification FAILED. n8n did not start successfully, or digest validation failed."
+    echo "   Run 'docker compose logs' to diagnose."
+    exit 1
 fi
 
 # ─── AUTO-UPGRADE ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements the security hardening improvements:
- Resolves upstream signature check TOCTOU by verifying directly against the resolved digest.
- Restricts verification and promotion to the linux/amd64 platform child manifest.
- Hardens install.sh admission checks to verify exact repository, workflow identity, and both build provenance and SBOM attestations.
- Enforces OpenVEX verification for the task runner image.
- Hardens the vulnerability policy to always block Critical CVEs and pre-auth network exploit vectors.
- Enables license scanning and blocks copyleft licenses (GPL, AGPL, LGPL) from auto-promoting.
- Restricts insecure bypass to require ARTIFACTGATE_ENV=lab and interactive confirmation.
- Strengthens health checks and post-deployment digest validation.