### PR TITLE
feat: 8-boolean evidence matrix, atomic CVSS evaluation, pinned yq, license policy, and AMD64 preflight

### DIFF
--- a/.github/scripts/enrich_findings.py
+++ b/.github/scripts/enrich_findings.py
@@ -179,28 +179,26 @@ def main():
                 gate_decision = "MANUAL_REVIEW"
                 gate_reasons.append("runtime_observation_unknown")
 
-        # Rule C: Parse CVSS vectors for network/pre-auth/low-complexity exploits (AV:N and PR:N and AC:L)
+        # Rule C: Parse CVSS vectors atomically for network/pre-auth/low-complexity exploits (AV:N and PR:N and AC:L/AT:N)
         cvss_data = vuln.get("CVSS", {})
         cvss_vectors = []
         for source in ["nvd", "redhat", "ghsa"]:
-            vec = cvss_data.get(source, {}).get("V3Vector")
-            if vec:
-                cvss_vectors.append(vec)
+            v3 = cvss_data.get(source, {}).get("V3Vector")
+            v4 = cvss_data.get(source, {}).get("V4Vector")
+            if v3:
+                cvss_vectors.append(v3)
+            if v4:
+                cvss_vectors.append(v4)
 
-        network_attack = False
-        pre_auth = False
-        low_complexity = False
+        network_exploit = False
         for vec in cvss_vectors:
-            parts = vec.split("/")
-            for part in parts:
-                if part == "AV:N":
-                    network_attack = True
-                if part == "PR:N":
-                    pre_auth = True
-                if part == "AC:L":
-                    low_complexity = True
+            parts = set(vec.split("/"))
+            # Atomic check per single vector
+            if {"AV:N", "PR:N", "AC:L"}.issubset(parts) or ({"AV:N", "PR:N"}.issubset(parts) and ("AC:L" in parts or "AT:N" in parts)):
+                network_exploit = True
+                break
 
-        if network_attack and pre_auth and low_complexity:
+        if network_exploit:
             gate_decision = "MANUAL_REVIEW"
             gate_reasons.append("network_preauth_low_complexity_exploit")
             summary["network_exploit_vector_count"] += 1
@@ -219,21 +217,36 @@ def main():
         vuln["GateDecision"] = gate_decision
         vuln["GateReasons"] = sorted(set(gate_reasons))
 
-    # 2. Process Licenses (In-place)
+    # 2. Process Licenses (In-place with policy classification)
+    # Load policy/license-policy.yml if available
+    deny_licenses = {"AGPL-1.0-only", "AGPL-1.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later", "SSPL-1.0"}
+    review_licenses = {"GPL-1.0-only", "GPL-1.0-or-later", "GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later", "LGPL-2.0-only", "LGPL-2.0-or-later", "LGPL-2.1-only", "LGPL-2.1-or-later", "LGPL-3.0-only", "LGPL-3.0-or-later", "MPL-1.1", "MPL-2.0", "EPL-1.0", "EPL-2.0"}
+
+    license_policy_path = "policy/license-policy.yml"
+    if os.path.exists(license_policy_path):
+        try:
+            with open(license_policy_path) as f:
+                import yaml
+                lic_pol = yaml.safe_load(f) or {}
+                if lic_pol.get("deny"):
+                    deny_licenses = set(lic_pol.get("deny"))
+                if lic_pol.get("manual_review"):
+                    review_licenses = set(lic_pol.get("manual_review"))
+        except Exception as exc:
+            print(f"Warning: Could not parse {license_policy_path}, using built-in defaults: {exc}", file=sys.stderr)
+
     for result in report.get("Results", []):
         for lic in result.get("Licenses") or []:
-            lic_name = lic.get("Name", lic.get("License", "UNKNOWN"))
-            severity = lic.get("Severity", "UNKNOWN")
+            lic_name = lic.get("Name", lic.get("License", "UNKNOWN")).strip()
             category = lic.get("Category", "").lower()
 
-            # Identify restricted copyleft licenses (GPL, AGPL, LGPL)
-            is_prohibited = category in {"restricted", "reciprocal"} or any(copyleft in lic_name.upper() for copyleft in ["GPL", "AGPL", "LGPL"])
+            needs_review = lic_name in deny_licenses or lic_name in review_licenses or category in {"restricted", "reciprocal"}
 
             lic_decision = "AUTO_ALLOWED"
             lic_reasons = []
-            if is_prohibited:
+            if needs_review:
                 lic_decision = "MANUAL_REVIEW"
-                lic_reasons.append(f"prohibited_license_{lic_name.lower()}")
+                lic_reasons.append(f"licence_requires_review_{lic_name.lower()}")
                 summary["prohibited_license_count"] += 1
                 summary["manual_review_count"] += 1
 

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install Trivy and cosign
+      - name: Install Trivy, cosign, and yq
         run: |
           sudo apt-get update
           sudo apt-get install -y wget apt-transport-https gnupg lsb-release jq
@@ -56,6 +56,11 @@ jobs:
             "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt"
           grep 'cosign-linux-amd64$' cosign_checksums.txt | sha256sum --check -
           sudo install -m 755 cosign-linux-amd64 /usr/local/bin/cosign
+          # Install yq for YAML policy parsing
+          YQ_VERSION=v4.44.1
+          curl --fail --show-error --location --retry 3 -o yq_linux_amd64 \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo install -m 755 yq_linux_amd64 /usr/local/bin/yq
 
       - name: Enforce Source Allowlist (Policy-as-Code)
         run: |
@@ -174,23 +179,33 @@ jobs:
           echo "### Upstream Vendor Signature Check" > vendor-sig-check.txt
           echo "Checking if n8nio/n8n publishes Sigstore/cosign signatures..." >> vendor-sig-check.txt
 
-          # Strictly validating n8n publisher OIDC issuer and identity to prevent impersonation on the resolved AMD64 digest
-          # Save verified signature bundle as promotion evidence
+          EXPIRY_DATE=$(yq eval '.vendor_signature.accepted_risk_expires_on' policy/image-ingestion-policy.yml | tr -d '"')
+          CURRENT_DATE=$(date -u +%Y-%m-%d)
+          if [ -n "$EXPIRY_DATE" ] && [ "$EXPIRY_DATE" != "null" ]; then
+            if [ "$CURRENT_DATE" \> "$EXPIRY_DATE" ]; then
+              echo "❌ VENDOR RISK EXPIRED: Accepted risk period ($EXPIRY_DATE) has elapsed on $CURRENT_DATE."
+              echo "   Upstream vendor signature is required. Halting promotion."
+              exit 1
+            fi
+          fi
+
           DIGEST="${{ steps.fetch-digest.outputs.digest }}"
-          if cosign verify "n8nio/n8n@$DIGEST" \
-              --certificate-identity-regexp="https://github.com/n8nio/n8n/.github/workflows/release.yml@.*" \
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" > upstream-signature-bundle.json 2>&1; then
+          COSIGN_OUT=$(cosign verify "n8nio/n8n@$DIGEST" \
+              --certificate-identity-regexp="https://github.com/n8nio/n8n/.github/workflows/release.yml@refs/(heads/master|tags/v.*)" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" 2>&1 || true)
+
+          if echo "$COSIGN_OUT" | grep -q "Verification for"; then
             echo "✅ Vendor signature VERIFIED — n8n publishes strictly-scoped Sigstore signatures." >> vendor-sig-check.txt
-            echo "Signature Bundle certificate and logging details archived in upstream-signature-bundle.json." >> vendor-sig-check.txt
-          else
+            echo "$COSIGN_OUT" > upstream-signature-bundle.json
+          elif echo "$COSIGN_OUT" | grep -iqE "no matching signatures|no signatures found"; then
             echo "⚠️  VENDOR RISK GAP: n8nio/n8n does not publish Sigstore/cosign signatures on this digest." >> vendor-sig-check.txt
             echo "   Publisher identity cannot be cryptographically verified upstream." >> vendor-sig-check.txt
-            echo "   Mitigations in place (per policy/image-ingestion-policy.yml):" >> vendor-sig-check.txt
-            echo "   - Source allowlisted to n8nio/n8n only" >> vendor-sig-check.txt
-            echo "   - Strict semver tag enforcement (no moving targets)" >> vendor-sig-check.txt
-            echo "   - Immutable SHA256 digest pinning throughout pipeline" >> vendor-sig-check.txt
-            echo "   Accepted risk: see policy/image-ingestion-policy.yml vendor_signature.accepted_risk" >> vendor-sig-check.txt
-            echo "⚠️ Upstream signature verification failed (risk accepted per policy)." > upstream-signature-bundle.json
+            echo "   Accepted risk expiry: $EXPIRY_DATE (Valid)" >> vendor-sig-check.txt
+            echo "⚠️ Upstream signature verification skipped (no signature published; risk accepted per policy)." > upstream-signature-bundle.json
+          else
+            echo "❌ CRITICAL SECURITY ERROR: Upstream signature verification FAILED due to invalid signature or identity mismatch!"
+            echo "$COSIGN_OUT"
+            exit 1
           fi
           cat vendor-sig-check.txt
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The promotion pipeline handles images in a strict, zero-trust workflow:
 
 ### Detailed Workflow Steps:
 
-1. **Intake & Digest Pinning**: Downstream references are resolved to immutable OCI SHA256 digests at intake. This guarantees that the exact code evaluated during building matches the code running in production.
+1. **Intake & Digest Pinning**: Downstream references are resolved to immutable OCI SHA256 digests for the `linux/amd64` architecture at intake. ArtifactGate currently admits only Linux AMD64 workload images to guarantee byte-level parity between scanned and deployed objects. This guarantees that the exact code evaluated during building matches the code running in production.
 2. **Static Vulnerability & Threat Scan**: Trivy extracts a complete SPDX SBOM and scans container layers for secrets, licensing liabilities, and vulnerability CVE records.
 3. **Dynamic Observation**: The container is executed in a quarantine test harness. **Tracee** uses kernel-level eBPF tracing to audit loaded shared libraries and system calls. **OWASP ZAP** performs a DAST baseline scan to identify web interface exposures.
 4. **Policy Decision Engine**: Scans are enriched with real-time risk metrics (CISA KEV catalog active exploitation status and FIRST EPSS exploit probability). If the image violates rules in `vulnerability-gate-policy.yml` (e.g. active KEV exploits or high-risk unknown items), it fails closed. High-risk items require documented, expiring OpenVEX waivers approved in the GitHub Actions environment.

--- a/docs/architecture-and-trust.md
+++ b/docs/architecture-and-trust.md
@@ -13,7 +13,7 @@ vendor or container is universally secure.
 
 1. **Upstream candidate** — an allowed vendor reference that has not yet earned a
    deployment decision. A moving label such as `latest` is resolved to a semantic
-   version and then to immutable application and runner digests.
+   version and then to immutable application and runner digests for the `linux/amd64` architecture. ArtifactGate currently admits only Linux AMD64 workload images to guarantee byte-level parity between scanned and deployed objects.
 2. **Assessed pair** — the exact digests have composition, vulnerability, malware,
    secret, licence and bounded runtime evidence attached. This evidence can still
    contain unknowns and findings.

--- a/iac/n8n/install.sh
+++ b/iac/n8n/install.sh
@@ -136,6 +136,15 @@ if ! command -v docker &> /dev/null; then
     exit 1
 fi
 
+HOST_PLATFORM="$(get_docker_host_platform)"
+if [ "$HOST_PLATFORM" != "linux/amd64" ]; then
+    echo "❌ ADMISSION ERROR: ArtifactGate currently admits only linux/amd64 workload images."
+    echo "   Detected host platform: $HOST_PLATFORM"
+    echo "   Multi-platform architectural admission is restricted to linux/amd64 to guarantee evaluated byte parity."
+    echo "❌ Deployment aborted."
+    exit 1
+fi
+
 # ─── DETECT HOST IP ─────────────────────────────────────────────────────────
 DETECTED_IP="127.0.0.1"
 
@@ -245,88 +254,75 @@ if [ "$INSECURE_LAB_MODE" = true ]; then
     echo "   ⚠️  INSECURE LAB BYPASS ACTIVE: Cryptographic provenance verification is disabled."
     echo "      [AUDIT LOG ENTRY] Verification bypassed by request on $(date)"
 else
-    HAS_VERIFIED=false
-    VERIFICATION_FAILED=false
+    APP_SIG_VERIFIED=false
+    RUNNER_SIG_VERIFIED=false
+    APP_VEX_VERIFIED=false
+    RUNNER_VEX_VERIFIED=false
+    APP_PROV_VERIFIED=false
+    RUNNER_PROV_VERIFIED=false
+    APP_SBOM_VERIFIED=false
+    RUNNER_SBOM_VERIFIED=false
     
     COSIGN_IDENTITY="https://github.com/${REPO_SLUG}/.github/workflows/image-promotion.yml@refs/heads/main"
     COSIGN_ISSUER="https://token.actions.githubusercontent.com"
 
-    # 1. Attempt verification with Cosign (Keyless verify)
+    # 1. Attempt verification with Cosign (Keyless verify for signatures, OpenVEX, Provenance, SBOM)
     if command -v cosign &> /dev/null; then
         echo "   🔍 Running Cosign keyless verification..."
         
-        # Verify Signatures
-        if cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && \
-           cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1; then
-            echo "   ✅ Cosign signatures verified for both application and runner."
-            
-            # Verify OpenVEX Attestations for both images
-            if cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && \
-               cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1; then
-                echo "   ✅ Cosign OpenVEX attestations verified for both images."
-                HAS_VERIFIED=true
-            else
-                echo "   ❌ Cosign OpenVEX attestation missing or invalid for one or both images."
-                VERIFICATION_FAILED=true
-            fi
-        else
-            echo "   ❌ Cosign signature verification failed for one or both images."
-            VERIFICATION_FAILED=true
-        fi
+        cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && APP_SIG_VERIFIED=true
+        cosign verify --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1 && RUNNER_SIG_VERIFIED=true
+
+        cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 && APP_VEX_VERIFIED=true
+        cosign verify-attestation --type openvex --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1 && RUNNER_VEX_VERIFIED=true
+
+        (cosign verify-attestation --type slsaprovenance --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type https://slsa.dev/provenance/v1 --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1) && APP_PROV_VERIFIED=true
+
+        (cosign verify-attestation --type slsaprovenance --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type https://slsa.dev/provenance/v1 --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1) && RUNNER_PROV_VERIFIED=true
+
+        (cosign verify-attestation --type spdxjson --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type spdx --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type https://spdx.dev/Document --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_IMAGE}@${GHCR_DIGEST}" >/dev/null 2>&1) && APP_SBOM_VERIFIED=true
+
+        (cosign verify-attestation --type spdxjson --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type spdx --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1 || \
+         cosign verify-attestation --type https://spdx.dev/Document --certificate-identity="$COSIGN_IDENTITY" --certificate-oidc-issuer="$COSIGN_ISSUER" "${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" >/dev/null 2>&1) && RUNNER_SBOM_VERIFIED=true
     fi
     
-    # 2. Attempt verification with GitHub CLI (with explicit identity/repo/predicate constraints)
-    if [ "$VERIFICATION_FAILED" = false ] && command -v gh &> /dev/null && gh auth status &> /dev/null 2>&1; then
-        echo "   🔍 Running GitHub CLI attestation verification..."
+    # 2. Attempt verification with GitHub CLI for any remaining unverified provenance or SBOM items
+    if command -v gh &> /dev/null && gh auth status &> /dev/null 2>&1; then
+        echo "   🔍 Checking GitHub CLI attestation API for build provenance and SBOMs..."
         
-        # Provenance constraints
-        if gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" \
-             --repo "$REPO_SLUG" \
-             --cert-identity "$COSIGN_IDENTITY" \
-             --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1 && \
-           gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" \
-             --repo "$REPO_SLUG" \
-             --cert-identity "$COSIGN_IDENTITY" \
-             --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1; then
-            echo "   ✅ GitHub SLSA build provenance verified."
-            
-            # SBOM constraints
-            if gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" \
-                 --repo "$REPO_SLUG" \
-                 --cert-identity "$COSIGN_IDENTITY" \
-                 --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1 && \
-               gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" \
-                 --repo "$REPO_SLUG" \
-                 --cert-identity "$COSIGN_IDENTITY" \
-                 --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1; then
-                echo "   ✅ GitHub SBOM attestations verified."
-                HAS_VERIFIED=true
-            else
-                echo "   ❌ GitHub SBOM attestation missing or invalid."
-                VERIFICATION_FAILED=true
-            fi
-        else
-            echo "   ❌ GitHub SLSA build provenance verification failed."
-            VERIFICATION_FAILED=true
-        fi
+        [ "$APP_PROV_VERIFIED" = true ] || gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" --repo "$REPO_SLUG" --cert-identity "$COSIGN_IDENTITY" --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1 && APP_PROV_VERIFIED=true
+        [ "$RUNNER_PROV_VERIFIED" = true ] || gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" --repo "$REPO_SLUG" --cert-identity "$COSIGN_IDENTITY" --predicate-type "https://slsa.dev/provenance/v1" >/dev/null 2>&1 && RUNNER_PROV_VERIFIED=true
+        [ "$APP_SBOM_VERIFIED" = true ] || gh attestation verify "oci://${GHCR_IMAGE}@${GHCR_DIGEST}" --repo "$REPO_SLUG" --cert-identity "$COSIGN_IDENTITY" --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1 && APP_SBOM_VERIFIED=true
+        [ "$RUNNER_SBOM_VERIFIED" = true ] || gh attestation verify "oci://${GHCR_RUNNER_IMAGE}@${RUNNER_GHCR_DIGEST}" --repo "$REPO_SLUG" --cert-identity "$COSIGN_IDENTITY" --predicate-type "https://spdx.dev/Document" >/dev/null 2>&1 && RUNNER_SBOM_VERIFIED=true
     fi
     
-    # 3. Decision
-    if [ "$VERIFICATION_FAILED" = true ]; then
+    # 3. Decision — ALL 8 booleans must be true
+    echo "   📊 Evidence Matrix Status:"
+    echo "      - App Signature:              $([ "$APP_SIG_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - Runner Signature:           $([ "$RUNNER_SIG_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - App OpenVEX Waiver:         $([ "$APP_VEX_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - Runner OpenVEX Waiver:      $([ "$RUNNER_VEX_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - App SLSA Build Provenance:  $([ "$APP_PROV_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - Runner SLSA Build Provenance: $([ "$RUNNER_PROV_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - App SPDX SBOM:              $([ "$APP_SBOM_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+    echo "      - Runner SPDX SBOM:           $([ "$RUNNER_SBOM_VERIFIED" = true ] && echo '✅ VERIFIED' || echo '❌ MISSING/FAILED')"
+
+    if [ "$APP_SIG_VERIFIED" = true ] && [ "$RUNNER_SIG_VERIFIED" = true ] && \
+       [ "$APP_VEX_VERIFIED" = true ] && [ "$RUNNER_VEX_VERIFIED" = true ] && \
+       [ "$APP_PROV_VERIFIED" = true ] && [ "$RUNNER_PROV_VERIFIED" = true ] && \
+       [ "$APP_SBOM_VERIFIED" = true ] && [ "$RUNNER_SBOM_VERIFIED" = true ]; then
+        echo "✅ Full evidence matrix verified. Cryptographic trust verification passed."
+    else
         echo ""
-        echo "❌ SECURITY ALERT: Provenance verification FAILED."
-        echo "   The image may have been tampered with or did not originate from the trusted pipeline."
+        echo "❌ SECURITY ALERT: Cryptographic evidence matrix INCOMPLETE or INVALID."
+        echo "   All 8 required evidence items (Signatures, OpenVEX, SLSA Provenance, SPDX SBOM for both images) must pass."
         echo "   Deployment aborted."
         exit 1
-    elif [ "$HAS_VERIFIED" = false ]; then
-        echo ""
-        echo "⚠️  Provenance verification requires either Cosign or the GitHub CLI (gh) to be authenticated."
-        echo "   Please install Cosign (https://sigstore.dev) or authenticate the GitHub CLI (gh auth login)."
-        echo "   Alternatively, use --insecure-lab-mode for a local-only verification bypass."
-        echo "❌ Deployment aborted."
-        exit 1
-    else
-        echo "✅ Cryptographic trust verification passed."
     fi
 fi
 

--- a/policy/image-ingestion-policy.yml
+++ b/policy/image-ingestion-policy.yml
@@ -25,6 +25,7 @@ allowlist:
 #   skip      — No check performed (not recommended)
 vendor_signature:
   mode: "warn"
+  accepted_risk_expires_on: "2026-09-30"
 
   # Document the accepted risk when mode is 'warn'.
   # This is visible in every scan report artifact for audit purposes.

--- a/policy/license-policy.yml
+++ b/policy/license-policy.yml
@@ -1,0 +1,37 @@
+# License Compliance Policy
+# Categorizes software licenses for third-party component ingestion.
+# Changes require a Pull Request for auditability.
+
+deny:
+  - AGPL-1.0-only
+  - AGPL-1.0-or-later
+  - AGPL-3.0-only
+  - AGPL-3.0-or-later
+  - SSPL-1.0
+
+manual_review:
+  - GPL-1.0-only
+  - GPL-1.0-or-later
+  - GPL-2.0-only
+  - GPL-2.0-or-later
+  - GPL-3.0-only
+  - GPL-3.0-or-later
+  - LGPL-2.0-only
+  - LGPL-2.0-or-later
+  - LGPL-2.1-only
+  - LGPL-2.1-or-later
+  - LGPL-3.0-only
+  - LGPL-3.0-or-later
+  - MPL-1.1
+  - MPL-2.0
+  - EPL-1.0
+  - EPL-2.0
+
+allow:
+  - MIT
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - CC0-1.0
+  - Unlicense


### PR DESCRIPTION
Implements Phase 2 security hardening improvements:
- Unified 8-boolean admission evidence matrix in install.sh requiring Signatures, OpenVEX, SLSA build provenance, and SPDX SBOM for BOTH application and runner images.
- Atomic evaluation of CVSS vector attributes (AV:N/PR:N/AC:L) within single vector strings.
- Policy-driven license review via policy/license-policy.yml and logging of licence_requires_review.
- Pinned yq v4.44.1 installation in GitHub Actions workflows.
- Expiration tracking of accepted vendor risk (accepted_risk_expires_on) and differentiation between absent signatures vs invalid/mismatched signatures.
- Preflight AMD64 host architecture enforcement in install.sh and updated documentation.