### PR TITLE
ci: run test_security_review_remediations.py in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           echo "Running ShellCheck on bash scripts..."
           shellcheck iac/n8n/install.sh iac/n8n/upgrade.sh .github/scripts/*.sh
           python3 .github/scripts/test_validate_compose.py
+          # Covers validate_predicate, validate_vex, and validate_sbom — the last of
+          # which gates promotion at image-promotion.yml. Needs no OPA binary.
+          python3 .github/scripts/test_security_review_remediations.py
 
       - name: Install OPA & Test Rego Policies
         run: |


### PR DESCRIPTION
Follow-up to #56, which flagged this gap.

## Problem

`.github/scripts/test_security_review_remediations.py` covers `validate_predicate`, `validate_vex`, and `validate_sbom` — but **no workflow ran it**. `ci.yml` invoked only `test_validate_compose.py` and `test_opa_remediations.py`.

That matters because `validate_sbom` gates promotion at `image-promotion.yml:630` (and `:631` for the runner SBOM). A regression in it would have shipped silently.

This was also how the dead-code chain in #56 stayed invisible: the suite was the *only* importer of the unreferenced `generate_promotion_decision.py`, and because nothing ran the suite, nothing surfaced that either file was orphaned.

## Change

One line added to the existing **ShellCheck Scripts & Policy Tests** step.

### Why that step, not the OPA step

The suite imports only `validate_promotion_decision`, `validate_vex`, and `validate_sbom` — all pure stdlib (`sys`, `json`, `os`, `argparse`, `datetime`), with no `subprocess` and no OPA dependency.

This is load-bearing, not incidental: the ShellCheck step runs *before* OPA is installed, so a hidden OPA dependency would fail there. Placing it in the earlier step also means it fails fast, before the OPA download.

## Verification

- **Runs clean with no OPA on PATH**, under `env -i` with a minimal environment — confirming it is safe in the pre-OPA step.
- **Mutation-tested to confirm it actually gates.** Forcing `validate_sbom` to `return True` unconditionally makes the suite report `FAILED (failures=1)` rather than passing silently. Wiring in a test that cannot fail would be pointless; this one catches the regression it claims to. `validate_sbom.py` was restored unmodified afterwards — this PR touches only `ci.yml`.
- **`actionlint`**: no errors. `ci.yml` shellcheck findings unchanged from baseline (12 `SC2086` / 1 `SC2129`) — none introduced.
- **Full local CI-equivalent run passes**: shellcheck, `test_validate_compose.py`, `test_security_review_remediations.py` (3 tests), Rego `PASS: 8/8`, `test_opa_remediations.py` (3 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)