### PR TITLE
fix: make the GHCR idempotency check actually detect promoted versions

### DIFF
--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      packages: read
       security-events: write
     steps:
       - name: Checkout repository
@@ -110,10 +111,37 @@ jobs:
             VERSION="$REQUESTED"
           fi
 
-          # Check if this version has already been promoted to our GHCR (Idempotency Check)
-          TOKEN="${{ secrets.GITHUB_TOKEN }}"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "https://ghcr.io/v2/${{ github.repository }}/n8n-trusted/manifests/$VERSION")
-          RUNNER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "https://ghcr.io/v2/${{ github.repository }}/n8n-runners-trusted/manifests/$VERSION")
+          # Check if this version has already been promoted to our GHCR (Idempotency Check).
+          # Two things this request must get right, or it always reports "not promoted":
+          #   1. Promoted tags are OCI image indexes (docker buildx imagetools create).
+          #      GHCR answers 404 unless Accept lists that media type, so reuse
+          #      ACCEPT_HEADER here exactly as the Docker Hub lookups below do.
+          #   2. The /v2/ manifest API wants a registry token exchanged from
+          #      GITHUB_TOKEN via ghcr.io/token, not GITHUB_TOKEN presented directly.
+          #      The job grants packages: read so that exchange carries pull scope.
+          # A lookup failure must fall through to a normal scan+promote (safe), never
+          # to a false "already promoted" skip, so anything other than 200 continues.
+          ghcr_manifest_status() {
+            local pkg="$1" ver="$2" tok code
+            tok=$(curl -s -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:${{ github.repository }}/${pkg}:pull" \
+              | jq -r '.token // empty')
+            if [ -z "$tok" ]; then
+              echo "000"
+              return
+            fi
+            # `|| true` keeps a transient network error from aborting the step under
+            # `bash -e`; curl still emits 000, which reads as "not promoted".
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $tok" \
+              -H "Accept: $ACCEPT_HEADER" \
+              "https://ghcr.io/v2/${{ github.repository }}/${pkg}/manifests/${ver}" || true)
+            echo "${code:-000}"
+          }
+
+          STATUS=$(ghcr_manifest_status n8n-trusted "$VERSION")
+          RUNNER_STATUS=$(ghcr_manifest_status n8n-runners-trusted "$VERSION")
+          echo "GHCR idempotency check for $VERSION: n8n-trusted=$STATUS n8n-runners-trusted=$RUNNER_STATUS"
           if [ "$STATUS" = "200" ] && [ "$RUNNER_STATUS" = "200" ]; then
             echo "✅ Version $VERSION application and runner are already promoted."
             echo "No action required. Exiting gracefully."


### PR DESCRIPTION
Found while trying to verify #56 end-to-end. **#56 fixed what happens *when* the idempotency guard fires. It turns out the guard never fired.**

## Root cause

The check asks GHCR whether the version's manifest already exists. Two independent things made that request always report "not promoted":

**1. Missing `Accept` header.** Promoted tags are OCI image indexes — `docker buildx imagetools create` writes `application/vnd.oci.image.index.v1+json`. GHCR answers **404** unless the request's `Accept` lists that media type.

Verified against the live registry, same token, only the header varying:

```
n8n-trusted:         no-Accept=404  with-Accept=200
n8n-runners-trusted: no-Accept=404  with-Accept=200
```

The step *already* defines `ACCEPT_HEADER` and applies it to every Docker Hub lookup below. It simply was not applied to the two GHCR lookups.

**2. Missing `packages` permission.** The job's `permissions` block listed `contents` / `issues` / `security-events` but not `packages`. When a `permissions` block is present, unlisted scopes default to `none`, so `GITHUB_TOKEN` carried no package read access. The `/v2/` manifest API also expects a registry token exchanged via `ghcr.io/token`, not `GITHUB_TOKEN` presented directly as a bearer.

## Impact

`skip_promotion` was always `false`. Every dispatch re-ran the full scan and re-promoted an already-promoted version, cutting a duplicate release each time — the exact waste the guard exists to prevent.

It also means the failure #56 describes (cosign invoked with an empty digest) was latent rather than active: the path that triggers it was unreachable. #56's guards are still correct and still required — they are what makes this fix safe to turn on.

## Change

- `packages: read` added to the `scan-images` job.
- Registry token exchanged via `ghcr.io/token`.
- `ACCEPT_HEADER` sent on both lookups, reusing the value already defined in the step.
- Both status codes logged, so a real run shows exactly what was observed.

### Failure direction is deliberate

Anything other than `200` falls through to a normal scan + promote. A wrong "not promoted" wastes a run; a wrong "already promoted" would silently skip a promotion that was actually needed. The manifest `curl` carries `|| true` so a transient network error cannot abort the step under `bash -e`, and instead reads as `000` → proceed.

## Verification

Against the **real** GHCR registry, exercising both directions:

```
2.31.3  -> n8n-trusted=200 runners=200 => SKIP (already promoted)
9.99.99 -> n8n-trusted=404 runners=404 => PROCEED (scan+promote)
```

- `actionlint`: no errors.
- Embedded-shellcheck findings unchanged from baseline (33 `SC2086` / 5 `SC2129`) — the new function adds none.
- Extracted step body passes `bash -n` and `shellcheck -S warning` with no findings.
- #56's step guards confirmed still intact.

### What I could not verify locally

The token exchange was tested via the **anonymous** path, since these packages are public. The authenticated `-u actor:GITHUB_TOKEN` exchange is the standard documented GHCR flow but I cannot exercise it without a token, so it is confirmed only by the logged status codes on a real run. That is why both codes are now echoed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)