### PR TITLE
fix: fall back to an anonymous GHCR token, and cover the check with shellcheck

### DIFF
--- a/.github/scripts/ghcr_manifest_status.sh
+++ b/.github/scripts/ghcr_manifest_status.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Report the HTTP status of a GHCR manifest lookup — the promotion idempotency check.
+#
+# Usage: ghcr_manifest_status.sh <owner/repo> <package> <version>
+#
+# Echoes the HTTP status code, or 000 when no registry token could be obtained
+# or the request itself failed.
+#
+# Callers must treat anything other than 200 as "not promoted" and fall through
+# to a normal scan+promote. The asymmetry is deliberate: a wrong "not promoted"
+# only costs a redundant run, while a wrong "already promoted" would silently
+# skip a promotion that was actually needed.
+#
+# Two details this request has to get right, or it always reports 404:
+#   1. Promoted tags are OCI image indexes (docker buildx imagetools create).
+#      GHCR answers 404 unless Accept lists that media type.
+#   2. The /v2/ manifest API wants a registry token exchanged via ghcr.io/token,
+#      not GITHUB_TOKEN presented directly as a bearer.
+#
+# GITHUB_TOKEN (optional) authenticates the exchange, which is required for
+# private packages. If it is absent or rejected, the exchange retries
+# anonymously so the check still works for public packages.
+set -euo pipefail
+
+REPOSITORY="${1:?repository required (owner/repo)}"
+PACKAGE="${2:?package required}"
+VERSION="${3:?version required}"
+
+ACCEPT_HEADER='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+TOKEN_URL="https://ghcr.io/token?service=ghcr.io&scope=repository:${REPOSITORY}/${PACKAGE}:pull"
+
+registry_token=""
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    registry_token=$(curl -s -u "${GITHUB_ACTOR:-x-access-token}:${GITHUB_TOKEN}" "$TOKEN_URL" \
+        | jq -r '.token // empty' || true)
+fi
+
+if [ -z "$registry_token" ]; then
+    registry_token=$(curl -s "$TOKEN_URL" | jq -r '.token // empty' || true)
+fi
+
+if [ -z "$registry_token" ]; then
+    echo "000"
+    exit 0
+fi
+
+# `|| true` keeps a transient network error from aborting the caller under
+# `bash -e`; curl still emits 000, which reads as "not promoted".
+status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${registry_token}" \
+    -H "Accept: ${ACCEPT_HEADER}" \
+    "https://ghcr.io/v2/${REPOSITORY}/${PACKAGE}/manifests/${VERSION}" || true)
+
+echo "${status:-000}"

--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -111,36 +111,16 @@ jobs:
             VERSION="$REQUESTED"
           fi
 
-          # Check if this version has already been promoted to our GHCR (Idempotency Check).
-          # Two things this request must get right, or it always reports "not promoted":
-          #   1. Promoted tags are OCI image indexes (docker buildx imagetools create).
-          #      GHCR answers 404 unless Accept lists that media type, so reuse
-          #      ACCEPT_HEADER here exactly as the Docker Hub lookups below do.
-          #   2. The /v2/ manifest API wants a registry token exchanged from
-          #      GITHUB_TOKEN via ghcr.io/token, not GITHUB_TOKEN presented directly.
-          #      The job grants packages: read so that exchange carries pull scope.
-          # A lookup failure must fall through to a normal scan+promote (safe), never
-          # to a false "already promoted" skip, so anything other than 200 continues.
-          ghcr_manifest_status() {
-            local pkg="$1" ver="$2" tok code
-            tok=$(curl -s -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
-              "https://ghcr.io/token?service=ghcr.io&scope=repository:${{ github.repository }}/${pkg}:pull" \
-              | jq -r '.token // empty')
-            if [ -z "$tok" ]; then
-              echo "000"
-              return
-            fi
-            # `|| true` keeps a transient network error from aborting the step under
-            # `bash -e`; curl still emits 000, which reads as "not promoted".
-            code=$(curl -s -o /dev/null -w "%{http_code}" \
-              -H "Authorization: Bearer $tok" \
-              -H "Accept: $ACCEPT_HEADER" \
-              "https://ghcr.io/v2/${{ github.repository }}/${pkg}/manifests/${ver}" || true)
-            echo "${code:-000}"
-          }
-
-          STATUS=$(ghcr_manifest_status n8n-trusted "$VERSION")
-          RUNNER_STATUS=$(ghcr_manifest_status n8n-runners-trusted "$VERSION")
+          # Check if this version has already been promoted to our GHCR (Idempotency
+          # Check). See .github/scripts/ghcr_manifest_status.sh for why the Accept
+          # header and the ghcr.io/token exchange both matter here. Anything other
+          # than 200 falls through to a normal scan+promote, which is the safe
+          # direction: a false "already promoted" would skip a needed promotion.
+          chmod +x .github/scripts/ghcr_manifest_status.sh
+          STATUS=$(GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" GITHUB_ACTOR="${{ github.actor }}" \
+            .github/scripts/ghcr_manifest_status.sh "${{ github.repository }}" n8n-trusted "$VERSION")
+          RUNNER_STATUS=$(GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" GITHUB_ACTOR="${{ github.actor }}" \
+            .github/scripts/ghcr_manifest_status.sh "${{ github.repository }}" n8n-runners-trusted "$VERSION")
           echo "GHCR idempotency check for $VERSION: n8n-trusted=$STATUS n8n-runners-trusted=$RUNNER_STATUS"
           if [ "$STATUS" = "200" ] && [ "$RUNNER_STATUS" = "200" ]; then
             echo "✅ Version $VERSION application and runner are already promoted."


### PR DESCRIPTION
Closes the one unverified assumption left by #58.

## Problem

#58 made the idempotency check actually work, but it authenticates the `ghcr.io/token` exchange with `GITHUB_TOKEN` — and I could not exercise that path locally, so it shipped unverified.

If that exchange were rejected, the check returned `000` → "not promoted" → **a full scan and a duplicate re-promotion of a version already present**, cutting a redundant release. Safe in the sense that it never wrongly skips, but wasteful — and it meant dispatching the workflow to verify the fix was a gamble rather than a verification.

## Change

**1. Anonymous fallback.** If the authenticated exchange yields no token, retry anonymously. GHCR issues anonymous pull tokens for public packages, so the check now works whether or not the authenticated path succeeds, while still preferring the authenticated token that private packages require.

**2. Extracted to `.github/scripts/ghcr_manifest_status.sh`.** `ci.yml` shellchecks `.github/scripts/*.sh`, but **nothing shellchecks inline workflow shell** — only `actionlint`, which isn't in CI. Moving the logic there gives it real CI coverage rather than local-only linting, and shortens a `fetch-digest` step that had grown long.

## Verification

Tested against the **live** registry, including the exact failure mode that motivated the change. Case 3 is the one that matters — a deliberately **invalid** `GITHUB_TOKEN`, simulating a rejected authenticated exchange:

| Case | Result | Decision |
|---|---|---|
| no token, `2.31.3` (promoted) | `200` / `200` | SKIP |
| no token, `9.99.99` (nonexistent) | `404` | PROCEED |
| **invalid token**, `2.31.3` (promoted) | **`200`** | SKIP — fallback works |
| nonexistent package | `000` | PROCEED |

Previously case 3 would have returned `000` and triggered a redundant promotion. It now resolves correctly.

- `shellcheck` passes on the **exact CI command**, with the new script now included in the glob.
- `actionlint`: no errors.
- Embedded-shellcheck findings unchanged from baseline (33 `SC2086` / 5 `SC2129`).
- #56's step guards and the `skip_promotion` job output confirmed intact; `packages: read` retained.

## Effect

A `workflow_dispatch` against an already-promoted version should now be a genuine no-op regardless of how the token exchange resolves — which is what makes the end-to-end check safe to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)