### PR TITLE
docs(site): link each case study and drop the K8s admission controller row

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -20,7 +20,6 @@ This document provides an authoritative control status inventory and an operatio
 | **Upstream Publisher Signature** | Implemented | Warning | Evaluates vendor signatures when present; recorded as accepted identity gap when missing |
 | **Promotion Attestation** | Implemented | Blocking at Installer | Keylessly signs and attaches `promotiondecision` predicates to promoted images in GHCR |
 | **Deployment Admission Verification** | Implemented | Blocking (`install.sh`) | `install.sh` verifies Cosign signatures, SLSA provenance, OpenVEX, and 4-digest pairing before startup |
-| **Kubernetes Admission Controller** | Not Implemented | None | Production adoption requires a Kubernetes admission controller (e.g. Kyverno / Sigstore policy-controller) |
 | **Scheduled Re-scanning** | Implemented | Issue Creation | `rescan.yml` re-scans promoted images weekly; creates GitHub issues on vulnerability decay |
 | **Automated Revocation** | Not Implemented | None | Automated runtime image eviction or registry tombstoning is not implemented |
 

--- a/site/index.html
+++ b/site/index.html
@@ -814,12 +814,6 @@ Registry ──► Resolve ──► Evidence ──► OPA Decision ──► P
               <td>`install.sh` verifies Cosign signatures, SLSA provenance, OpenVEX, and 4-digest pairing.</td>
             </tr>
             <tr>
-              <td><strong>K8s Admission Controller</strong></td>
-              <td><span class="badge badge-rose">Not Implemented</span></td>
-              <td>None</td>
-              <td>Production adoption requires a Kubernetes admission controller (Kyverno / Sigstore policy-controller).</td>
-            </tr>
-            <tr>
               <td><strong>Scheduled Re-scanning</strong></td>
               <td><span class="badge badge-emerald">Implemented</span></td>
               <td>Issue Creation</td>
@@ -840,25 +834,25 @@ Registry ──► Resolve ──► Evidence ──► OPA Decision ──► P
       <div class="grid-2">
         <div class="card">
           <span class="badge badge-rose" style="margin-bottom:0.75rem;">Case 1</span>
-          <h3>`tj-actions/changed-files` (Action Compromise)</h3>
+          <h3><a href="https://github.com/llody9977/artifactgate/blob/main/docs/incident-case-studies.md#case-study-1-tj-actionschanged-files-cicd-action-compromise" target="_blank" rel="noopener">`tj-actions/changed-files` (Action Compromise)</a></h3>
           <p><strong>Failure Mode</strong>: Mutable release tags (`:v40`) were hijacked upstream to execute malicious secret exfiltration code.</p>
           <p><strong>ArtifactGate Control</strong>: All workflow actions and container intake resolve strictly to immutable SHA-256 commit digests.</p>
         </div>
         <div class="card">
           <span class="badge badge-rose" style="margin-bottom:0.75rem;">Case 2</span>
-          <h3>XZ Utils Backdoor (Targeted Logic Bomb)</h3>
+          <h3><a href="https://github.com/llody9977/artifactgate/blob/main/docs/incident-case-studies.md#case-study-2-xz-utils-backdoor-targeted-maintainer--build-compromise" target="_blank" rel="noopener">XZ Utils Backdoor (Targeted Logic Bomb)</a></h3>
           <p><strong>Failure Mode</strong>: Trusted maintainer inserted build-time backdoor into tarball sources that bypassed static code review.</p>
           <p><strong>ArtifactGate Control</strong>: Tracee kernel eBPF dynamic syscall observation monitors unexpected binary execution in quarantine.</p>
         </div>
         <div class="card">
           <span class="badge badge-rose" style="margin-bottom:0.75rem;">Case 3</span>
-          <h3>SolarWinds (Vendor Build Compromise)</h3>
+          <h3><a href="https://github.com/llody9977/artifactgate/blob/main/docs/incident-case-studies.md#case-study-3-solarwinds-orion-vendor-build-pipeline-compromise" target="_blank" rel="noopener">SolarWinds (Vendor Build Compromise)</a></h3>
           <p><strong>Failure Mode</strong>: Valid vendor code-signing certificates signed malicious build updates (`SUNBURST`).</p>
           <p><strong>ArtifactGate Control</strong>: Independently evaluates security evidence and attests downstream promotion predicates (`promotiondecision`).</p>
         </div>
         <div class="card">
           <span class="badge badge-rose" style="margin-bottom:0.75rem;">Case 4</span>
-          <h3>Equifax Apache Struts (Remediation SLA Breakdown)</h3>
+          <h3><a href="https://github.com/llody9977/artifactgate/blob/main/docs/incident-case-studies.md#case-study-4-equifax-apache-struts-vulnerability-management-sla-breakdown" target="_blank" rel="noopener">Equifax Apache Struts (Remediation SLA Breakdown)</a></h3>
           <p><strong>Failure Mode</strong>: Known CVE-2017-5638 patch existed but unpatched application remained exposed for months.</p>
           <p><strong>ArtifactGate Control</strong>: OpenVEX waivers enforce accountable risk owners, expiration dates (`expires_on`), and active CVE coverage validation.</p>
         </div>


### PR DESCRIPTION
## Engineering Case Studies & Control Derivations — per-case links

Each case card title in the site's Case Studies section now links to its full write-up in `docs/incident-case-studies.md`:

- Case 1 → `#case-study-1-tj-actionschanged-files-cicd-action-compromise`
- Case 2 → `#case-study-2-xz-utils-backdoor-targeted-maintainer--build-compromise`
- Case 3 → `#case-study-3-solarwinds-orion-vendor-build-pipeline-compromise`
- Case 4 → `#case-study-4-equifax-apache-struts-vulnerability-management-sla-breakdown`

**Link format:** absolute GitHub blob URLs, not relative `docs/` paths. `pages.yml` publishes only the `site/` directory, so a relative `docs/...` link 404s on the deployed page. Anchors were verified against the doc's actually-rendered anchors on GitHub, not just computed — the fragile segments (`tj-actionschanged-files`, `cicd`, the `--` from `&`) match exactly.

## Remove the "K8s Admission Controller" row

Removed the `K8s Admission Controller` / `Kubernetes Admission Controller` row from the controls status table in both `site/index.html` and `docs/implementation-status.md`. The broader admission-architecture content and the maturity-roadmap prose are left unchanged — only the dedicated status-table row is gone.

## Verification

- No `K8s Admission Controller` / `Kubernetes Admission Controller` string remains anywhere in the tree.
- All four case anchors confirmed against GitHub's rendered `docs/incident-case-studies.md`.
- `site/index.html` tag balance checked with an HTML parser — no unclosed tags introduced.