### PR TITLE
ci: use stable Trivy code-scanning categories instead of per-version ones

### DIFF
--- a/.github/workflows/image-promotion.yml
+++ b/.github/workflows/image-promotion.yml
@@ -380,7 +380,10 @@ jobs:
         if: always() && steps.fetch-digest.outputs.skip_promotion != 'true' && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
-          category: "image-promotion-${{ env.N8N_VERSION }}"
+          # Stable category — a per-version value spawns a new code-scanning
+          # configuration each run that then goes permanently stale (tool-status
+          # warning). One stable category keeps a single, always-current configuration.
+          category: "trivy-image-promotion"
           ref: refs/heads/main
           sha: ${{ github.sha }}
 

--- a/.github/workflows/rescan.yml
+++ b/.github/workflows/rescan.yml
@@ -275,7 +275,12 @@ jobs:
         uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: "sarifs/rescan-${{ steps.rescan.outputs.version }}.sarif"
-          category: "rescan-${{ steps.rescan.outputs.version }}"
+          # Stable category: code scanning uses category to distinguish analyses of
+          # the same commit, not to version a subject over time. A per-version value
+          # spawns a new configuration each run that then goes permanently stale and
+          # trips the tool-status warning. One stable category keeps a single, always-
+          # current configuration (and lets alerts close when a finding is remediated).
+          category: "trivy-rescan"
 
       - name: Upload SARIFs as internal artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## The warning

The Trivy tool-status page flags the `.github/workflows/rescan.yml` configuration. Root cause: both `rescan.yml` and `image-promotion.yml` uploaded Trivy SARIF with a **per-version `category`** (`rescan-<v>`, `image-promotion-<v>`).

In code scanning, `category` distinguishes analyses of the **same commit** (e.g. different tools or languages) — it is not meant to version a subject over time. A per-version value spawns a brand-new configuration on every run, each analyzed exactly once and then never updated. **33 configurations** had piled up (one per version, per workflow), all but the two newest stale by weeks to months — and GitHub flags stale configurations.

## The fix

One stable category per workflow:

| Workflow | Before | After |
|---|---|---|
| `rescan.yml` | `rescan-${version}` | `trivy-rescan` |
| `image-promotion.yml` | `image-promotion-${N8N_VERSION}` | `trivy-image-promotion` |

Now each run updates a single, always-current configuration, and code-scanning alerts **close automatically** when a finding is remediated instead of being stranded in a dead per-version config. The two workflows keep distinct categories so they don't clobber each other's results.

## Scope

This stops **new** stale configurations from forming. The **existing** 31 stale per-version configurations are historical analyses in the Security tab; clearing those is a separate data-cleanup step (deleting old analyses), handled outside this code change. The per-version SARIFs remain retained as workflow artifacts and release assets regardless.

## Verification

- `actionlint`: no errors on either workflow.
- No per-version Trivy category remains in any workflow (`codeql.yml`'s `/language:python` is unrelated and correct).